### PR TITLE
[stable10] Enable by default

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0"?>
 <info>
     <id>serverinfo</id>
-    <name>Server Info</name>
+    <name>Server info</name>
     <description>Provider useful server information</description>
     <licence>AGPL</licence>
     <author>Bjoern Schiessle</author>
-    <version>0.0.1</version>
+    <version>1.1.0</version>
     <namespace>ServerInfo</namespace>
     <category>other</category>
     <dependencies>
         <owncloud min-version="9.1" max-version="9.1" />
     </dependencies>
+    <default_enable/>
 </info>


### PR DESCRIPTION
backport of https://github.com/nextcloud/serverinfo/pull/9