### PR TITLE
[stable10] use the new OCS Data Response

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -91,22 +91,20 @@ class ApiController extends OCSController {
 	public function info() {
 
 		return new DataResponse(
-			['data' =>
-				[
-					'nextcloud' =>
-						[
-							'system' => $this->systemStatistics->getSystemStatistics(),
-							'storage' => $this->storageStatistics->getStorageStatistics(),
-							'shares' => $this->shareStatistics->getShareStatistics()
-						],
-					'server' =>
-						[
-							'webserver' => $this->getWebserver(),
-							'php' => $this->phpStatistics->getPhpStatistics(),
-							'database' => $this->databaseStatistics->getDatabaseStatistics()
-						],
-					'activeUsers' => $this->sessionStatistics->getSessionStatistics()
-				]
+			[
+				'nextcloud' =>
+					[
+						'system' => $this->systemStatistics->getSystemStatistics(),
+						'storage' => $this->storageStatistics->getStorageStatistics(),
+						'shares' => $this->shareStatistics->getShareStatistics()
+					],
+				'server' =>
+					[
+						'webserver' => $this->getWebserver(),
+						'php' => $this->phpStatistics->getPhpStatistics(),
+						'database' => $this->databaseStatistics->getDatabaseStatistics()
+					],
+				'activeUsers' => $this->sessionStatistics->getSessionStatistics()
 			]
 		);
 

--- a/tests/lib/Controller/ApiControllerTest.php
+++ b/tests/lib/Controller/ApiControllerTest.php
@@ -122,16 +122,16 @@ class ApiControllerTest extends TestCase {
 		$result = $this->instance->info();
 		$this->assertTrue($result instanceof DataResponse);
 		$data = $result->getData();
-		$this->assertTrue(isset($data['data']['nextcloud']));
-		$this->assertTrue(isset($data['data']['server']));
+		$this->assertTrue(isset($data['nextcloud']));
+		$this->assertTrue(isset($data['server']));
 
-		$this->assertSame('systemStatistics', $data['data']['nextcloud']['system']);
-		$this->assertSame('storageStatistics', $data['data']['nextcloud']['storage']);
-		$this->assertSame('shareStatistics', $data['data']['nextcloud']['shares']);
-		$this->assertSame('unknown', $data['data']['server']['webserver']);
-		$this->assertSame('databaseStatistics', $data['data']['server']['database']);
-		$this->assertSame('phpStatistics', $data['data']['server']['php']);
-		$this->assertSame('sessionStatistics', $data['data']['activeUsers']);
+		$this->assertSame('systemStatistics', $data['nextcloud']['system']);
+		$this->assertSame('storageStatistics', $data['nextcloud']['storage']);
+		$this->assertSame('shareStatistics', $data['nextcloud']['shares']);
+		$this->assertSame('unknown', $data['server']['webserver']);
+		$this->assertSame('databaseStatistics', $data['server']['database']);
+		$this->assertSame('phpStatistics', $data['server']['php']);
+		$this->assertSame('sessionStatistics', $data['activeUsers']);
 	}
 
 }


### PR DESCRIPTION
- [x] requires https://github.com/nextcloud/server/pull/823

backport of https://github.com/nextcloud/serverinfo/pull/19