### PR TITLE
Handle older kernels when returning free memory.

### DIFF
--- a/lib/SystemStatistics.php
+++ b/lib/SystemStatistics.php
@@ -81,8 +81,15 @@ class SystemStatistics {
 			$data[$k] = $v;
 		}
 
+		if (array_key_exists('MemAvailable', $data)) {
+			// MemAvailable is only present in newer kernels (after 2014).
+			$available = $data['MemAvailable'];
+		} else {
+			$available = $data['MemFree'];
+		}
+
 		return [
-			'mem_free' => (int)$data['MemAvailable'] + (int)$data['SwapFree'],
+			'mem_free' => (int)$available + (int)$data['SwapFree'],
 			'mem_total' => (int)$data['MemTotal'] + (int)$data['SwapTotal']
 		];
 	}


### PR DESCRIPTION
The property "MemAvailable" was only introduced in newer kernels after
2014, so for older versions "MemFree" must be used. This fixes #43.