### PR TITLE
fix SQL syntax error on newer MariaDB

### DIFF
--- a/lib/DatabaseStatistics.php
+++ b/lib/DatabaseStatistics.php
@@ -93,7 +93,7 @@ class DatabaseStatistics {
 		switch ($this->config->getSystemValue('dbtype')) {
 			case 'mysql':
 				$db_name = $this->config->getSystemValue('dbname');
-				$sql = 'SHOW TABLE STATUS FROM ' . $db_name;
+				$sql = 'SHOW TABLE STATUS FROM `' . $db_name . '`';
 				$result = $this->connection->executeQuery($sql);
 				$database_size = 0;
 				while ($row = $result->fetch()) {


### PR DESCRIPTION
On MariaDB 10.0.27 and 10.1.19, enclose the database name in `

Fix #54