### PR TITLE
[stable11] Don't throw an error when /proc/meminfo is not readable

### DIFF
--- a/lib/SystemStatistics.php
+++ b/lib/SystemStatistics.php
@@ -68,7 +68,7 @@ class SystemStatistics {
 	 * @return array with the two values 'mem_free' and 'mem_total'
 	 */
 	protected function getMemoryUsage() {
-		$memoryUsage = file_get_contents('/proc/meminfo');
+		$memoryUsage = @file_get_contents('/proc/meminfo');
 		if ($memoryUsage === false) {
 			return ['mem_free' => 'N/A', 'mem_total' => 'N/A'];
 		}


### PR DESCRIPTION
Backport of #71 