### PR TITLE
[stable10] fix SQL syntax error on MariaDB 10.0.27 and 10.1.19

### DIFF
--- a/lib/DatabaseStatistics.php
+++ b/lib/DatabaseStatistics.php
@@ -93,7 +93,7 @@ class DatabaseStatistics {
 		switch ($this->config->getSystemValue('dbtype')) {
 			case 'mysql':
 				$db_name = $this->config->getSystemValue('dbname');
-				$sql = 'SHOW TABLE STATUS FROM ' . $db_name;
+				$sql = 'SHOW TABLE STATUS FROM `' . $db_name . '`';
 				$result = $this->connection->executeQuery($sql);
 				$database_size = 0;
 				while ($row = $result->fetch()) {


### PR DESCRIPTION
Backport #65  for https://github.com/nextcloud/server/issues/3140