### PR TITLE
Use is_readable() to check if meminfo can be read

### DIFF
--- a/lib/SystemStatistics.php
+++ b/lib/SystemStatistics.php
@@ -68,7 +68,12 @@ class SystemStatistics {
 	 * @return array with the two values 'mem_free' and 'mem_total'
 	 */
 	protected function getMemoryUsage() {
-		$memoryUsage = @file_get_contents('/proc/meminfo');
+		$memoryUsage = false;
+		if (is_readable('/proc/meminfo')) {
+			// read meminfo from OS
+			$memoryUsage = file_get_contents('/proc/meminfo');
+		}
+		// check if memoryUsage failed
 		if ($memoryUsage === false) {
 			return ['mem_free' => 'N/A', 'mem_total' => 'N/A'];
 		}


### PR DESCRIPTION
IMHO it's a bit more elegant way to check if meminfo can be read using is_readable(), instead of suppressing all warnings and errors for file_get_contents().