### PR TITLE
Fixed phpMemLimit not being humanReadable-ized

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -35,6 +35,7 @@
 		updateActiveUsersStatistics();
 		updateShareStatistics();
 		setHumanReadableSizeToElement("dataBaseSize");
+		setHumanReadableSizeToElement("phpMemLimit");
 		setHumanReadableSizeToElement("phpUploadMaxSize");
 
 		function updateInfo() {


### PR DESCRIPTION
The display of the current PHP memory_limit on the info site did not get converted to a human readable value. That's fixed now.