### PR TITLE
keep the server setting at the top, right after "overview" and "basic settings"

### DIFF
--- a/lib/Settings/AdminSection.php
+++ b/lib/Settings/AdminSection.php
@@ -63,10 +63,10 @@ class AdminSection implements IIconSection {
 	 * the settings navigation. The sections are arranged in ascending order of
 	 * the priority values. It is required to return a value between 0 and 99.
 	 *
-	 * keep the server setting at the top, right after "server settings"
+	 * keep the server setting at the top, right after "overview" and "basic settings"
 	 */
 	public function getPriority() {
-		return 0;
+		return 1;
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,7 +6,7 @@ if (!defined('PHPUNIT_RUN')) {
 
 require_once __DIR__ . '/../../../lib/base.php';
 
-if(!class_exists('PHPUnit_Framework_TestCase')) {
+if(!class_exists('\PHPUnit\Framework\TestCase')) {
 	require_once('PHPUnit/Autoload.php');
 }
 \OC_App::loadApp('serverinfo');


### PR DESCRIPTION
keep the server setting at the top, right after "overview" and "basic settings"
