### PR TITLE
Make appinfo/info.xml NC14-compliant

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<info>
+<info xmlns:xsi= "http://www.w3.org/2001/XMLSchema-instance"
+	  xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
     <id>serverinfo</id>
     <name>Monitoring</name>
     <summary>Monitoring app with useful server information</summary>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,12 +10,13 @@
     <author>Ivan Sein Santiago</author>
     <namespace>ServerInfo</namespace>
     <category>monitoring</category>
+    <bugs>https://github.com/nextcloud/serverinfo/issues</bugs>
+    <dependencies>
+        <nextcloud min-version="14" max-version="14" />
+    </dependencies>
     <settings>
         <admin>\OCA\ServerInfo\Settings\AdminSettings</admin>
         <admin-section>\OCA\ServerInfo\Settings\AdminSection</admin-section>
     </settings>
-    <dependencies>
-        <nextcloud min-version="14" max-version="14" />
-    </dependencies>
     <default_enable/>
 </info>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,10 +4,10 @@
     <name>Monitoring</name>
     <summary>Monitoring app with useful server information</summary>
     <description>Provides useful server information, such as CPU load, RAM usage, disk usage, number of users, etc.</description>
+    <version>1.4.0</version>
     <licence>AGPL</licence>
     <author>Bjoern Schiessle</author>
     <author>Ivan Sein Santiago</author>
-    <version>1.4.0</version>
     <namespace>ServerInfo</namespace>
     <category>other</category>
     <dependencies>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,17 +5,17 @@
     <summary>Monitoring app with useful server information</summary>
     <description>Provides useful server information, such as CPU load, RAM usage, disk usage, number of users, etc.</description>
     <version>1.4.0</version>
-    <licence>AGPL</licence>
+    <licence>agpl</licence>
     <author>Bjoern Schiessle</author>
     <author>Ivan Sein Santiago</author>
     <namespace>ServerInfo</namespace>
-    <category>other</category>
-    <dependencies>
-		<nextcloud min-version="14" max-version="14" />
-    </dependencies>
-    <default_enable/>
+    <category>monitoring</category>
     <settings>
         <admin>\OCA\ServerInfo\Settings\AdminSettings</admin>
         <admin-section>\OCA\ServerInfo\Settings\AdminSection</admin-section>
     </settings>
+    <dependencies>
+        <nextcloud min-version="14" max-version="14" />
+    </dependencies>
+    <default_enable/>
 </info>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -2,6 +2,7 @@
 <info>
     <id>serverinfo</id>
     <name>Monitoring</name>
+    <summary>Monitoring app with useful server information</summary>
     <description>Provides useful server information, such as CPU load, RAM usage, disk usage, number of users, etc.</description>
     <licence>AGPL</licence>
     <author>Bjoern Schiessle</author>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,14 +9,14 @@
     <author>Bjoern Schiessle</author>
     <author>Ivan Sein Santiago</author>
     <namespace>ServerInfo</namespace>
+    <default_enable/>
     <category>monitoring</category>
     <bugs>https://github.com/nextcloud/serverinfo/issues</bugs>
     <dependencies>
         <nextcloud min-version="14" max-version="14" />
     </dependencies>
     <settings>
-        <admin>\OCA\ServerInfo\Settings\AdminSettings</admin>
-        <admin-section>\OCA\ServerInfo\Settings\AdminSection</admin-section>
+        <admin>OCA\ServerInfo\Settings\AdminSettings</admin>
+        <admin-section>OCA\ServerInfo\Settings\AdminSection</admin-section>
     </settings>
-    <default_enable/>
 </info>


### PR DESCRIPTION
This PR should fix following error of certain CI tasks by providing a `<summary>` tag within the `info.xml` file:
```
Invalid appinfo.xml file found: Element 'description': This element is not expected. Expected is one of ( name, summary ).
```