### PR TITLE
Fix static call of OC_Helper

### DIFF
--- a/lib/SystemStatistics.php
+++ b/lib/SystemStatistics.php
@@ -195,14 +195,10 @@ class SystemStatistics {
 		if (!function_exists($function_name)) {
 			return false;
 		}
-		$disabled = explode(',', $this->phpIni->get('disable_functions') ?: '');
-		$disabled = array_map('trim', $disabled);
-		if (in_array($function_name, $disabled)) {
+		if ($this->phpIni->listContains('disable_functions', $function_name)) {
 			return false;
 		}
-		$disabled = explode(',', $this->phpIni->get('suhosin.executor.func.blacklist') ?: '');
-		$disabled = array_map('trim', $disabled);
-		if (in_array($function_name, $disabled)) {
+		if ($this->phpIni->listContains('suhosin.executor.func.blacklist', $function_name)) {
 			return false;
 		}
 		return true;

--- a/lib/SystemStatistics.php
+++ b/lib/SystemStatistics.php
@@ -87,7 +87,7 @@ class SystemStatistics {
 	}
 
 	/**
-	 * get available and free memory including both RAM and Swap
+	 * Get available and free memory including both RAM and Swap
 	 *
 	 * @return array with the two values 'mem_free' and 'mem_total'
 	 */
@@ -100,24 +100,24 @@ class SystemStatistics {
 		//If FreeBSD is used and exec()-usage is allowed
         if (PHP_OS === 'FreeBSD' && $this->is_function_enabled('exec')) {
 			//Read Swap usage:
-			exec("/usr/sbin/swapinfo",$return,$status);
-			if ($status===0 && count($return) > 1) {
+			exec("/usr/sbin/swapinfo", $return, $status);
+			if ($status === 0 && count($return) > 1) {
 				$line = preg_split("/[\s]+/", $return[1]);
 				if(count($line) > 3) {
-					$swapTotal = (int) $line[3];
-					$swapFree = $swapTotal- (int) $line[2];
+					$swapTotal = (int)$line[3];
+					$swapFree = $swapTotal - (int)$line[2];
 				}
 			}
 			unset($status);
 			unset($return);
 			//Read Memory Usage
-			exec("/sbin/sysctl -n hw.physmem hw.pagesize vm.stats.vm.v_inactive_count vm.stats.vm.v_cache_count vm.stats.vm.v_free_count",$return,$status);
-			if ($status===0) {
-				$return=array_map('intval',$return);
+			exec("/sbin/sysctl -n hw.physmem hw.pagesize vm.stats.vm.v_inactive_count vm.stats.vm.v_cache_count vm.stats.vm.v_free_count", $return, $status);
+			if ($status === 0) {
+				$return = array_map('intval', $return);
 				if ($return === array_filter($return, 'is_int')) {
 					return [
-						'mem_total' => (int) $return[0]/1024,
-						'mem_free' => (int) $return[1]*($return[2]+$return[3]+$return[4])/1024,
+						'mem_total' => (int)$return[0]/1024,
+						'mem_free' => (int)$return[1] * ($return[2] + $return[3] + $return[4]) / 1024,
 						'swap_free' => (isset($swapFree)) ? $swapFree : 'N/A',
 						'swap_total' => (isset($swapTotal)) ? $swapTotal : 'N/A'
 					];

--- a/lib/SystemStatistics.php
+++ b/lib/SystemStatistics.php
@@ -198,9 +198,6 @@ class SystemStatistics {
 		if ($this->phpIni->listContains('disable_functions', $function_name)) {
 			return false;
 		}
-		if ($this->phpIni->listContains('suhosin.executor.func.blacklist', $function_name)) {
-			return false;
-		}
 		return true;
 	}
 

--- a/lib/SystemStatistics.php
+++ b/lib/SystemStatistics.php
@@ -37,6 +37,8 @@ class SystemStatistics {
 	private $appManager;
 	/** @var AppFetcher */
 	private $appFetcher;
+	/** @var OC_Helper */
+	private $ocHelper;
 
 	/**
 	 * SystemStatistics constructor.
@@ -45,11 +47,12 @@ class SystemStatistics {
 	 * @param IAppManager $appManager
 	 * @param AppFetcher $appFetcher
 	 */
-	public function __construct(IConfig $config, IAppManager $appManager, AppFetcher $appFetcher) {
+	public function __construct(IConfig $config, IAppManager $appManager, AppFetcher $appFetcher, \OC_Helper $ocHelper) {
 		$this->config = $config;
 		$this->view = new View();
 		$this->appManager = $appManager;
 		$this->appFetcher = $appFetcher;
+		$this->ocHelper = $ocHelper;
 	}
 
 	/**
@@ -91,7 +94,7 @@ class SystemStatistics {
 			$memoryUsage = file_get_contents('/proc/meminfo');
 		}
 		//If FreeBSD is used and exec()-usage is allowed
-		if (PHP_OS === 'FreeBSD' && \OC_Helper::is_function_enabled('exec')) {
+		if (PHP_OS === 'FreeBSD' && $this->ocHelper->is_function_enabled('exec')) {
 			//Read Swap usage:
 			exec("/usr/sbin/swapinfo",$return,$status);
 			if ($status===0 && count($return) > 1) {

--- a/lib/SystemStatistics.php
+++ b/lib/SystemStatistics.php
@@ -38,8 +38,8 @@ class SystemStatistics {
 	private $appManager;
 	/** @var Installer */
 	private $installer;
-    /** @var IniGetWrapper */
-    protected $phpIni;
+	/** @var IniGetWrapper */
+	protected $phpIni;
 
 	/**
 	 * SystemStatistics constructor.
@@ -47,7 +47,7 @@ class SystemStatistics {
 	 * @param IConfig $config
 	 * @param IAppManager $appManager
 	 * @param Installer $installer
-     * @param IniGetWrapper $phpIni
+	 * @param IniGetWrapper $phpIni
 	 * @throws \Exception
 	 */
 	public function __construct(IConfig $config, IAppManager $appManager, Installer $installer, IniGetWrapper $phpIni) {
@@ -55,7 +55,7 @@ class SystemStatistics {
 		$this->view = new View();
 		$this->appManager = $appManager;
 		$this->installer = $installer;
-        $this->phpIni = $phpIni;
+		$this->phpIni = $phpIni;
 	}
 
 	/**
@@ -98,7 +98,7 @@ class SystemStatistics {
 			$memoryUsage = file_get_contents('/proc/meminfo');
 		}
 		//If FreeBSD is used and exec()-usage is allowed
-        if (PHP_OS === 'FreeBSD' && $this->is_function_enabled('exec')) {
+		if (PHP_OS === 'FreeBSD' && $this->is_function_enabled('exec')) {
 			//Read Swap usage:
 			exec("/usr/sbin/swapinfo", $return, $status);
 			if ($status === 0 && count($return) > 1) {
@@ -184,28 +184,28 @@ class SystemStatistics {
 		return $info;
 	}
 
-    /**
-     * Checks if a function is available. Borrowed from
-     * https://github.com/nextcloud/server/blob/2e36069e24406455ad3f3998aa25e2a949d1402a/lib/private/legacy/helper.php#L475
-     *
-     * @param string $function_name
-     * @return bool
-     */
-    public function is_function_enabled($function_name) {
-        if (!function_exists($function_name)) {
-            return false;
-        }
-        $disabled = explode(',', $this->phpIni->get('disable_functions') ?: '');
-        $disabled = array_map('trim', $disabled);
-        if (in_array($function_name, $disabled)) {
-            return false;
-        }
-        $disabled = explode(',', $this->phpIni->get('suhosin.executor.func.blacklist') ?: '');
-        $disabled = array_map('trim', $disabled);
-        if (in_array($function_name, $disabled)) {
-            return false;
-        }
-        return true;
-    }
+	/**
+	 * Checks if a function is available. Borrowed from
+	 * https://github.com/nextcloud/server/blob/2e36069e24406455ad3f3998aa25e2a949d1402a/lib/private/legacy/helper.php#L475
+	 *
+	 * @param string $function_name
+	 * @return bool
+	 */
+	public function is_function_enabled($function_name) {
+		if (!function_exists($function_name)) {
+			return false;
+		}
+		$disabled = explode(',', $this->phpIni->get('disable_functions') ?: '');
+		$disabled = array_map('trim', $disabled);
+		if (in_array($function_name, $disabled)) {
+			return false;
+		}
+		$disabled = explode(',', $this->phpIni->get('suhosin.executor.func.blacklist') ?: '');
+		$disabled = array_map('trim', $disabled);
+		if (in_array($function_name, $disabled)) {
+			return false;
+		}
+		return true;
+	}
 
 }


### PR DESCRIPTION
Fixes static call of OC_Helper, causing the app not being compliant:
```
# sudo -u www-data php /var/www/nextcloud/occ app:check-code serverinfo
Analysing /var/www/nextcloud/apps/serverinfo/lib/SystemStatistics.php
 1 errors
    line   96: OC_Helper - Static method of private class must not be called
```

Together with PR #126 the app is now fully compliant, based on testing on NC14 RC2:
```
# sudo -u www-data php /var/www/nextcloud/occ app:check-code serverinfo
App is compliant - awesome job!
```