### PR TITLE
Adds tooltip to make people aware of API JSON format

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -25,7 +25,7 @@
 		swapUsageLine,
 		cpuLoadChart,
 		cpuLoadLine,
-		activeusersChart,
+		activeUsersChart,
 		sharesChart;
 
 	$(document).ready(function () {
@@ -199,10 +199,10 @@
 			stepSize = 1;
 		}
 
-		if (typeof activeusersChart === 'undefined') {
+		if (typeof activeUsersChart === 'undefined') {
 			var ctx = document.getElementById("activeuserscanvas");
 
-			activeusersChart = new Chart(ctx, {
+			activeUsersChart = new Chart(ctx, {
 				type: 'line',
 				data: {
 					labels: [

--- a/js/script.js
+++ b/js/script.js
@@ -41,6 +41,7 @@
 		setHumanReadableSizeToElement("phpUploadMaxSize");
 		setHumanReadableSizeToElement("systemDiskFreeSpace");
 
+		$('#ocsEndPoint span.icon-info').tooltip({placement: 'top'});
 		initMonitoringLinkToClipboard();
 		$("#monitoring-endpoint-url").on('click', function() {
 			$(this).select();

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -84,5 +84,6 @@ style('serverinfo', 'style');
 	<div>
 		<input type="text" readonly="readonly" id="monitoring-endpoint-url" value="<?php echo p($_['ocs']); ?>" />
 		<a class="clipboardButton icon icon-clippy" data-clipboard-target="#monitoring-endpoint-url"></a>
- 	</div>
+		<span class="icon-info svg" title="" data-original-title="<?php p($l->t('Did you know?')); ?> <?php p($l->t('Appending "?format=json" at the end of the URL gives you the result in JSON format!')); ?>"></span>
+	</div>
 </div>


### PR DESCRIPTION
This is a simple idea to make people aware about the JSON-possibility, if someone requires that. I would have used `<strong>` and `<em>` to make the tooltip just a little bit nicier, but that doesn't work out that quite well as HTML is not allowed within that tooltips - probably because of good reasons (e,g, XSS)

Looks like:
![image](https://user-images.githubusercontent.com/2029878/45064006-a5abcd80-b0b1-11e8-909b-5fa4ebbcc64a.png)

Way of formating mentioned in nextcloud/server#7474