### PR TITLE
Suppress error-log-entries og is_readable call

### DIFF
--- a/lib/SystemStatistics.php
+++ b/lib/SystemStatistics.php
@@ -94,7 +94,7 @@ class SystemStatistics {
 	 */
 	protected function getMemoryUsage() {
 		$memoryUsage = false;
-		if (is_readable('/proc/meminfo')) {
+		if (@is_readable('/proc/meminfo')) {
 			// read meminfo from OS
 			$memoryUsage = file_get_contents('/proc/meminfo');
 		}


### PR DESCRIPTION
Hello,

this might not be a good change as it seems to supress all error messages. Though it helps me running Nextcloud on a provider that gives me limited access to open_basedir or /proc/meminfo. Although you check for access, I still get lots of errors-log-entries when opening the Memory-System-Statistics that flood my logs:

```
is_readable(): open_basedir restriction in effect. File(/proc/meminfo) is not within the allowed path(s): (/var/www/vhosts/xxx.yyy.netcup.net/httpdocs/zzz.aaa.com/:/tmp/:/var/lib/php5/sessions:/var/www/vhosts/xxx.yyy.netcup.net/tmp) at /var/www/vhosts/xxx.yyy.netcup.net/httpdocs/zzz.aaa.com/apps/serverinfo/lib/SystemStatistics.php#96
```

Just as an idea, perhaps you guys have a better approach. Just discard it if it is nonesense. I could create a ticket otherwise.

Good work! :-)
Patrick