### PR TITLE
Avoid line breaks after long device names in "df" command

### DIFF
--- a/lib/OperatingSystems/DefaultOs.php
+++ b/lib/OperatingSystems/DefaultOs.php
@@ -154,7 +154,7 @@ class DefaultOs {
 	 */
 	public function getDiskInfo() {
 		$blacklist = ['', 'Type', 'tmpfs', 'devtmpfs'];
-		$data  = shell_exec('df -T');
+		$data  = shell_exec('df -TP');
 		$lines = preg_split('/[\r\n]+/', $data);
 
 		foreach ($lines as $line) {


### PR DESCRIPTION
Long device names cause unwanted line breaks after them in the `df` output. This leads to wrong parsing of the data:
![2020-02-26 22_59_46-mRemoteNG - confCons xml - Nextcloud](https://user-images.githubusercontent.com/9440351/75392246-e45bc600-58eb-11ea-9dac-2929c007eaf5.png)

The `-P` option fixes that (`-P, --portability / use the POSIX output format`):
![2020-02-26 23_00_06-mRemoteNG - confCons xml - Nextcloud](https://user-images.githubusercontent.com/9440351/75392258-ec1b6a80-58eb-11ea-981c-c7512beeea65.png)

Fixes #173