### PR TITLE
catch PHP error "Undefined variable: result"

### DIFF
--- a/lib/OperatingSystems/DefaultOs.php
+++ b/lib/OperatingSystems/DefaultOs.php
@@ -170,7 +170,7 @@ class DefaultOs {
 				$result[] = $items;
 			}
 		}
-		return $result;
+		return $result = $result ?? [];
 	}
 
 }


### PR DESCRIPTION
I keep getting errors in the log. Looks like $result was not set and this script was returning an unset variable. This PR catches the issue. In the case that $result is not set, this will catch the blank variable and gracefully assign $result to a blank array. 

Error | PHP | Undefined variable: result at /snap/nextcloud/20007/htdocs/apps/serverinfo/lib/OperatingSystems/DefaultOs.php#173 |   | 2020-04-06T15:57:13-0500



