### PR TITLE
Correct format for uptime is used

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -162,8 +162,8 @@ class ApiController extends OCSController {
 		}
 
 		$interval = $boot->diff(new \DateTime());
-		if ($interval->d > 0) {
-			return $interval->format('%d days, %h hours, %i minutes, %s seconds');
+		if ($interval->days > 0) {
+			return $interval->format('%a days, %h hours, %i minutes, %s seconds');
 		}
 		return $interval->format('%h hours, %i minutes, %s seconds');
 	}


### PR DESCRIPTION
Fix #219 

As described at https://www.php.net/manual/en/dateinterval.format.php

> `days` If the DateInterval object was created by DateTime::diff(), then this is the total number of days between the start and end dates. Otherwise, days will be FALSE. 

> `a`  Total number of days as a result of a DateTime::diff() or (unknown) otherwise