### PR TITLE
Match any non-whitespace character in filesystem pattern

### DIFF
--- a/lib/OperatingSystems/DefaultOs.php
+++ b/lib/OperatingSystems/DefaultOs.php
@@ -212,7 +212,7 @@ class DefaultOs {
 		}
 
 		$matches = [];
-		$pattern = '/^(?<Filesystem>[\w\/-]+)\s*(?<Type>\w+)\s*(?<Blocks>\d+)\s*(?<Used>\d+)\s*(?<Available>\d+)\s*(?<Capacity>\d+%)\s*(?<Mounted>[\w\/-]+)$/m';
+		$pattern = '/^(?<Filesystem>[\S]+)\s*(?<Type>\w+)\s*(?<Blocks>\d+)\s*(?<Used>\d+)\s*(?<Available>\d+)\s*(?<Capacity>\d+%)\s*(?<Mounted>[\w\/-]+)$/m';
 
 		$result = preg_match_all($pattern, $disks, $matches);
 		if ($result === 0 || $result === false) {

--- a/tests/data/df_tp
+++ b/tests/data/df_tp
@@ -9,3 +9,4 @@ tmpfs                                   tmpfs        4084000         0   4084000
 vagrant                                 vboxsf     958123168 614831132 343292036      65% /vagrant
 home_vagrant_code                       vboxsf     958123168 614831132 343292036      65% /home/vagrant/code
 tmpfs                                   tmpfs         816800         0    816800       0% /run/user/1000
+nfs.example.com:/export                 nfs4           14820         0      1230       0% /nfs

--- a/tests/lib/DefaultOsTest.php
+++ b/tests/lib/DefaultOsTest.php
@@ -171,6 +171,14 @@ class DefaultOsTest extends TestCase {
 				'percent' => '65%',
 				'mount' => '/home/vagrant/code',
 			],
+			[
+				'device' => 'nfs.example.com:/export',
+				'fs' => 'nfs4',
+				'used' => 0,
+				'available' => 1259520,
+				'percent' => '0%',
+				'mount' => '/nfs',
+			]
 		];
 
 		$this->assertSame($disks, $this->os->getDiskInfo());


### PR DESCRIPTION
Fix showing mounted nfs shares in the server info app