### PR TITLE
Normalize memory and disk values to MB

### DIFF
--- a/lib/OperatingSystems/DefaultOs.php
+++ b/lib/OperatingSystems/DefaultOs.php
@@ -50,12 +50,8 @@ class DefaultOs implements IOperatingSystem {
 		}
 
 		foreach ($matches['Key'] as $i => $key) {
-			$value = (int)$matches['Value'][$i];
-			$unit = $matches['Unit'][$i];
-
-			if ($unit === 'kB') {
-				$value *= 1024;
-			}
+			// Value is always in KB: https://github.com/torvalds/linux/blob/c70672d8d316ebd46ea447effadfe57ab7a30a50/fs/proc/meminfo.c#L58-L60
+			$value = (int)($matches['Value'][$i] / 1024);
 
 			switch ($key) {
 				case 'MemTotal':
@@ -195,7 +191,7 @@ class DefaultOs implements IOperatingSystem {
 		$data = [];
 
 		try {
-			$disks = $this->executeCommand('df -TP');
+			$disks = $this->executeCommand('df -TPk');
 		} catch (\RuntimeException $e) {
 			return $data;
 		}
@@ -216,8 +212,8 @@ class DefaultOs implements IOperatingSystem {
 			$disk = new Disk();
 			$disk->setDevice($filesystem);
 			$disk->setFs($matches['Type'][$i]);
-			$disk->setUsed((int)$matches['Used'][$i] * 1024);
-			$disk->setAvailable((int)$matches['Available'][$i] * 1024);
+			$disk->setUsed((int)($matches['Used'][$i] / 1024));
+			$disk->setAvailable((int)($matches['Available'][$i] / 1024));
 			$disk->setPercent($matches['Capacity'][$i]);
 			$disk->setMount($matches['Mounted'][$i]);
 

--- a/lib/OperatingSystems/FreeBSD.php
+++ b/lib/OperatingSystems/FreeBSD.php
@@ -53,8 +53,8 @@ class FreeBSD implements IOperatingSystem {
 
 		$result = preg_match_all($pattern, $swapinfo, $matches);
 		if ($result === 1) {
-			$data->setSwapTotal((int)$matches['Avail'][0]);
-			$data->setSwapFree($data->getSwapTotal() - (int)$matches['Used'][0]);
+			$data->setSwapTotal((int)($matches['Avail'][0] / 1024));
+			$data->setSwapFree(($data->getSwapTotal() - (int)($matches['Used'][0]) / 1024));
 		}
 
 		unset($matches, $result);
@@ -67,8 +67,8 @@ class FreeBSD implements IOperatingSystem {
 
 		$lines = explode("\n", $meminfo);
 		if (count($lines) > 4) {
-			$data->setMemTotal((int)$lines[0]);
-			$data->setMemAvailable((int)$lines[1] * ((int)$lines[2] + (int)$lines[3] + (int)$lines[4]));
+			$data->setMemTotal((int)($lines[0] / 1024 / 1024));
+			$data->setMemAvailable((int)(($lines[1] * ($lines[2] + $lines[3] + $lines[4])) / 1024 / 1024));
 		}
 
 		unset($lines);
@@ -239,8 +239,8 @@ class FreeBSD implements IOperatingSystem {
 			$disk = new Disk();
 			$disk->setDevice($filesystem);
 			$disk->setFs($matches['Type'][$i]);
-			$disk->setUsed((int)$matches['Used'][$i] * 1024);
-			$disk->setAvailable((int)$matches['Available'][$i] * 1024);
+			$disk->setUsed((int)($matches['Used'][$i] / 1024));
+			$disk->setAvailable((int)($matches['Available'][$i] / 1024));
 			$disk->setPercent($matches['Capacity'][$i]);
 			$disk->setMount($matches['Mounted'][$i]);
 

--- a/lib/Resources/Disk.php
+++ b/lib/Resources/Disk.php
@@ -49,18 +49,30 @@ class Disk {
 		$this->fs = $fs;
 	}
 
+	/**
+	 * @return int in MB
+	 */
 	public function getUsed(): int {
 		return $this->used;
 	}
 
+	/**
+	 * @param int $used in MB
+	 */
 	public function setUsed(int $used): void {
 		$this->used = $used;
 	}
 
+	/**
+	 * @return int in MB
+	 */
 	public function getAvailable(): int {
 		return $this->available;
 	}
 
+	/**
+	 * @param int $available in MB
+	 */
 	public function setAvailable(int $available): void {
 		$this->available = $available;
 	}

--- a/lib/Resources/Memory.php
+++ b/lib/Resources/Memory.php
@@ -32,42 +32,72 @@ class Memory {
 	private $swapTotal = -1;
 	private $swapFree = -1;
 
+	/**
+	 * @return int in MB
+	 */
 	public function getMemTotal(): int {
 		return $this->memTotal;
 	}
 
+	/**
+	 * @param int $memTotal in MB
+	 */
 	public function setMemTotal(int $memTotal): void {
 		$this->memTotal = $memTotal;
 	}
 
+	/**
+	 * @return int in MB
+	 */
 	public function getMemFree(): int {
 		return $this->memFree;
 	}
 
+	/**
+	 * @param int $memFree in MB
+	 */
 	public function setMemFree(int $memFree): void {
 		$this->memFree = $memFree;
 	}
 
+	/**
+	 * @return int in MB
+	 */
 	public function getMemAvailable(): int {
 		return $this->memAvailable;
 	}
 
+	/**
+	 * @param int $memAvailable in MB
+	 */
 	public function setMemAvailable(int $memAvailable): void {
 		$this->memAvailable = $memAvailable;
 	}
 
+	/**
+	 * @return int in MB
+	 */
 	public function getSwapTotal(): int {
 		return $this->swapTotal;
 	}
 
+	/**
+	 * @param int $swapTotal in MB
+	 */
 	public function setSwapTotal(int $swapTotal): void {
 		$this->swapTotal = $swapTotal;
 	}
 
+	/**
+	 * @return int in MB
+	 */
 	public function getSwapFree(): int {
 		return $this->swapFree;
 	}
-	
+
+	/**
+	 * @param int $swapFree in MB
+	 */
 	public function setSwapFree(int $swapFree): void {
 		$this->swapFree = $swapFree;
 	}

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -25,8 +25,8 @@ script('serverinfo', 'Chart.min');
 
 style('serverinfo', 'style');
 
-function FormatBytes($byte) {
-	$unim = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+function FormatMegabytes($byte) {
+	$unim = ['MB', 'GB', 'TB', 'PB'];
 	$count = 0;
 	while ($byte >= 1024) {
 		$count++;
@@ -66,7 +66,7 @@ $disks = $_['diskinfo'];
 						</tr>
 						<tr>
 							<td><?php p($l->t('Memory')); ?>:</td>
-							<td><?php p(FormatBytes($memory->getMemTotal())) ?></td>
+							<td><?php p(FormatMegabytes($memory->getMemTotal())) ?></td>
 						</tr>
 						<tr>
 							<td><?php p($l->t('Server time')); ?>:</td>
@@ -138,9 +138,9 @@ $disks = $_['diskinfo'];
 							<?php p($l->t('Filesystem')); ?> :
 							<span class="info"><?php p($disk->getFs()); ?></span><br>
 							<?php p($l->t('Size')); ?> :
-							<span class="info"><?php p(FormatBytes($disk->getUsed() + $disk->getAvailable())); ?></span><br>
+							<span class="info"><?php p(FormatMegabytes($disk->getUsed() + $disk->getAvailable())); ?></span><br>
 							<?php p($l->t('Available')); ?> :
-							<span class="info"><?php p(FormatBytes($disk->getAvailable())); ?></span><br>
+							<span class="info"><?php p(FormatMegabytes($disk->getAvailable())); ?></span><br>
 							<?php p($l->t('Used')); ?> :
 							<span class="info"><?php p($disk->getPercent()); ?></span><br>
 						</div>

--- a/tests/lib/DefaultOsTest.php
+++ b/tests/lib/DefaultOsTest.php
@@ -58,11 +58,11 @@ class DefaultOsTest extends TestCase {
 
 		$memory = $this->os->getMemory();
 
-		$this->assertEquals(16330252 * 1024, $memory->getMemTotal());
-		$this->assertEquals(2443908 * 1024, $memory->getMemFree());
-		$this->assertEquals(7675276 * 1024, $memory->getMemAvailable());
-		$this->assertEquals(999420 * 1024, $memory->getSwapTotal());
-		$this->assertEquals(917756 * 1024, $memory->getSwapFree());
+		$this->assertEquals(15947, $memory->getMemTotal());
+		$this->assertEquals(2386, $memory->getMemFree());
+		$this->assertEquals(7495, $memory->getMemAvailable());
+		$this->assertEquals(975, $memory->getSwapTotal());
+		$this->assertEquals(896, $memory->getSwapFree());
 	}
 
 	public function testGetMemoryNoData(): void {
@@ -131,38 +131,38 @@ class DefaultOsTest extends TestCase {
 
 	public function testGetDiskInfo(): void {
 		$this->os->method('executeCommand')
-			->with('df -TP')
+			->with('df -TPk')
 			->willReturn(file_get_contents(__DIR__ . '/../data/df_tp'));
 
 		$disk1 = new Disk();
 		$disk1->setDevice('/dev/mapper/homestead--vg-root');
 		$disk1->setFs('ext4');
-		$disk1->setUsed(6354399232);
-		$disk1->setAvailable(48456929280);
+		$disk1->setUsed(6060);
+		$disk1->setAvailable(46212);
 		$disk1->setPercent('12%');
 		$disk1->setMount('/');
 
 		$disk2 = new Disk();
 		$disk2->setDevice('/dev/mapper/homestead--vg-mysql--master');
 		$disk2->setFs('ext4');
-		$disk2->setUsed(263385088);
-		$disk2->setAvailable(63388057600);
+		$disk2->setUsed(251);
+		$disk2->setAvailable(60451);
 		$disk2->setPercent('1%');
 		$disk2->setMount('/homestead-vg/master');
 
 		$disk3 = new Disk();
 		$disk3->setDevice('vagrant');
 		$disk3->setFs('vboxsf');
-		$disk3->setUsed(629587079168);
-		$disk3->setAvailable(351531044864);
+		$disk3->setUsed(600421);
+		$disk3->setAvailable(335246);
 		$disk3->setPercent('65%');
 		$disk3->setMount('/vagrant');
 
 		$disk4 = new Disk();
 		$disk4->setDevice('home_vagrant_code');
 		$disk4->setFs('vboxsf');
-		$disk4->setUsed(629587079168);
-		$disk4->setAvailable(351531044864);
+		$disk4->setUsed(600421);
+		$disk4->setAvailable(335246);
 		$disk4->setPercent('65%');
 		$disk4->setMount('/home/vagrant/code');
 
@@ -170,7 +170,7 @@ class DefaultOsTest extends TestCase {
 		$disk5->setDevice('nfs.example.com:/export');
 		$disk5->setFs('nfs4');
 		$disk5->setUsed(0);
-		$disk5->setAvailable(1259520);
+		$disk5->setAvailable(1);
 		$disk5->setPercent('0%');
 		$disk5->setMount('/nfs');
 

--- a/tests/lib/FreeBSDTest.php
+++ b/tests/lib/FreeBSDTest.php
@@ -59,11 +59,11 @@ class FreeBSDTest extends TestCase {
 
 		$memory = $this->os->getMemory();
 
-		$this->assertEquals(68569628672, $memory->getMemTotal());
+		$this->assertEquals(65393, $memory->getMemTotal());
 		$this->assertEquals(-1, $memory->getMemFree());
-		$this->assertEquals(15809376256, $memory->getMemAvailable());
-		$this->assertEquals(3744300, $memory->getSwapTotal());
-		$this->assertEquals(3744300, $memory->getSwapFree());
+		$this->assertEquals(15076, $memory->getMemAvailable());
+		$this->assertEquals(3656, $memory->getSwapTotal());
+		$this->assertEquals(3656, $memory->getSwapFree());
 	}
 
 	public function testGetMemoryNoSwapinfo(): void {
@@ -79,9 +79,9 @@ class FreeBSDTest extends TestCase {
 
 		$memory = $this->os->getMemory();
 
-		$this->assertEquals(68569628672, $memory->getMemTotal());
+		$this->assertEquals(65393, $memory->getMemTotal());
 		$this->assertEquals(-1, $memory->getMemFree());
-		$this->assertEquals(15809376256, $memory->getMemAvailable());
+		$this->assertEquals(15076, $memory->getMemAvailable());
 		$this->assertEquals(-1, $memory->getSwapTotal());
 		$this->assertEquals(-1, $memory->getSwapFree());
 	}


### PR DESCRIPTION
Close #230 

`Argument 1 passed to OCA\\ServerInfo\\Resources\\Disk::setUsed() must be of the type int, float given`

Disk and Memory objects are strictly typed. That's a problem if you are using more than 2147483647 bytes on a 32 bit system. To workaround this issue I changed the units to MB and normalize the values before.  As hardening the last call is always `(int)`. 