### PR TITLE
Update calculation for used and available disk space in gigabyte.

### DIFF
--- a/lib/Os.php
+++ b/lib/Os.php
@@ -109,8 +109,8 @@ class Os implements IOperatingSystem {
 
 		foreach ($this->backend->getDiskInfo() as $disk) {
 			$data[] = [
-				round($disk->getUsed() / 1024 / 1024 / 1024, 1),
-				round($disk->getAvailable() / 1024 / 1024 / 1024, 1)
+				round($disk->getUsed() / 1024 , 1),
+				round($disk->getAvailable() / 1024, 1)
 			];
 		}
 


### PR DESCRIPTION
Fix #234 

After #231 the values returned by getUsed and getAvailable are already in megabyte. 

