### PR TITLE
Remove timeserver

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -437,7 +437,6 @@
 					var data = response.ocs.data;
 					document.getElementById("servertime").innerHTML = data.servertime;
 					document.getElementById("uptime").innerHTML = data.uptime;
-					document.getElementById("timeservers").innerHTML = data.timeservers;
 				},
 				error: function (data) {
 					console.log(data);

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -115,12 +115,10 @@ class ApiController extends OCSController {
 	public function BasicData(): DataResponse {
 		$servertime  = $this->os->getTime();
 		$uptime      = $this->formatUptime($this->os->getUptime());
-		$timeservers = $this->os->getTimeServers()[0];
 
 		return new DataResponse([
 			'servertime' => $servertime,
-			'uptime' => $uptime,
-			'timeservers' => $timeservers
+			'uptime' => $uptime
 		]);
 	}
 

--- a/lib/OperatingSystems/DefaultOs.php
+++ b/lib/OperatingSystems/DefaultOs.php
@@ -129,15 +129,6 @@ class DefaultOs implements IOperatingSystem {
 	/**
 	 * @return string
 	 */
-	public function getTimeServers() {
-		$servers = shell_exec('cat /etc/ntp.conf 2>/dev/null |grep  \'^pool\' | cut -f 2 -d " "');
-		$servers .= ' ' . shell_exec('cat /etc/systemd/timesyncd.conf 2>/dev/null |grep  \'^NTP=\' | cut -f 2 -d " "');
-		return $servers;
-	}
-
-	/**
-	 * @return string
-	 */
 	public function getNetworkInfo() {
 		$result = [];
 		$result['hostname'] = \gethostname();

--- a/lib/OperatingSystems/FreeBSD.php
+++ b/lib/OperatingSystems/FreeBSD.php
@@ -125,22 +125,6 @@ class FreeBSD implements IOperatingSystem {
 	/**
 	 * @return string
 	 */
-	public function getTimeServers() {
-		$servers = " ";
-
-		try {
-			$servers = $this->executeCommand('cat /etc/ntp.conf 2>/dev/null');
-			preg_match_all("/(?<=^pool ).\S*/m", $servers, $matches);
-			$allservers = implode(' ', $matches[0]);
-		} catch (\RuntimeException $e) {
-			return $servers;
-		}
-		return $allservers;
-	}
-
-	/**
-	 * @return string
-	 */
 	public function getNetworkInfo() {
 		$result = [];
 		$result['hostname'] = \gethostname();

--- a/lib/Os.php
+++ b/lib/Os.php
@@ -83,14 +83,6 @@ class Os implements IOperatingSystem {
 		return $this->backend->getUptime();
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getTimeServers() {
-		$data = $this->backend->getTimeServers();
-		return explode("\n", $data);
-	}
-
 	public function getDiskInfo(): array {
 		return $this->backend->getDiskInfo();
 	}

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -76,10 +76,6 @@ $disks = $_['diskinfo'];
 							<td><?php p($l->t('Uptime')); ?>:</td>
 							<td><span class="info" id="uptime"></span></td>
 						</tr>
-						<tr>
-							<td><?php p($l->t('Time Servers')); ?>:</td>
-							<td><span class="info" id="timeservers"></span></td>
-						</tr>
 						</tbody>
 					</table>
 				</div>


### PR DESCRIPTION
Close #188 #242 

Configured timeservers is a less important information. The current implementation show the timeservers only for some setups. For example chrony is not supported. On my Ubuntu box there are not timeservers shown because the defaults are used. 