### PR TITLE
[20] Fix Memory (#240)

### DIFF
--- a/lib/OperatingSystems/FreeBSD.php
+++ b/lib/OperatingSystems/FreeBSD.php
@@ -54,13 +54,13 @@ class FreeBSD implements IOperatingSystem {
 		$result = preg_match_all($pattern, $swapinfo, $matches);
 		if ($result === 1) {
 			$data->setSwapTotal((int)($matches['Avail'][0] / 1024));
-			$data->setSwapFree(($data->getSwapTotal() - (int)($matches['Used'][0]) / 1024));
+			$data->setSwapFree(($data->getSwapTotal() - (int)($matches['Used'][0] / 1024)));
 		}
 
 		unset($matches, $result);
 
 		try {
-			$meminfo = $this->executeCommand('/sbin/sysctl -n hw.physmem hw.pagesize vm.stats.vm.v_inactive_count vm.stats.vm.v_cache_count vm.stats.vm.v_free_count');
+			$meminfo = $this->executeCommand('/sbin/sysctl -n hw.realmem hw.pagesize vm.stats.vm.v_inactive_count vm.stats.vm.v_cache_count vm.stats.vm.v_free_count');
 		} catch (\RuntimeException $e) {
 			$meminfo = '';
 		}

--- a/tests/lib/FreeBSDTest.php
+++ b/tests/lib/FreeBSDTest.php
@@ -54,7 +54,7 @@ class FreeBSDTest extends TestCase {
 		$this->os->method('executeCommand')
 			->willReturnMap([
 				['/usr/sbin/swapinfo -k', file_get_contents(__DIR__ . '/../data/freebsd_swapinfo')],
-				['/sbin/sysctl -n hw.physmem hw.pagesize vm.stats.vm.v_inactive_count vm.stats.vm.v_cache_count vm.stats.vm.v_free_count', file_get_contents(__DIR__ . '/../data/freebsd_meminfo')],
+				['/sbin/sysctl -n hw.realmem hw.pagesize vm.stats.vm.v_inactive_count vm.stats.vm.v_cache_count vm.stats.vm.v_free_count', file_get_contents(__DIR__ . '/../data/freebsd_meminfo')],
 			]);
 
 		$memory = $this->os->getMemory();
@@ -72,7 +72,7 @@ class FreeBSDTest extends TestCase {
 				if ($command === '/usr/sbin/swapinfo -k') {
 					throw new \RuntimeException('No output for command: /usr/sbin/swapinfo');
 				}
-				if ($command === '/sbin/sysctl -n hw.physmem hw.pagesize vm.stats.vm.v_inactive_count vm.stats.vm.v_cache_count vm.stats.vm.v_free_count') {
+				if ($command === '/sbin/sysctl -n hw.realmem hw.pagesize vm.stats.vm.v_inactive_count vm.stats.vm.v_cache_count vm.stats.vm.v_free_count') {
 					return file_get_contents(__DIR__ . '/../data/freebsd_meminfo');
 				}
 			});


### PR DESCRIPTION
Backport of #240 

Cast swapFree to integer to fix typeerror.
Prevent float in swapinfo and update tests for hw.realmem

(cherry picked from commit 49952d29bb24c6592ba1ec820b930d007f6bb6c5)