### PR TITLE
Fix FreeBSD Interface Exception

### DIFF
--- a/lib/OperatingSystems/FreeBSD.php
+++ b/lib/OperatingSystems/FreeBSD.php
@@ -184,8 +184,13 @@ class FreeBSD implements IOperatingSystem {
 				preg_match("/(?<=\<).*(?=-)/m", $intface, $duplex);
 
 				$iface['mac'] = implode(' ', $mac[0]);
-				$iface['status'] = $status[0];
 				$iface['speed']  = $speed[0];
+
+				if ($status[0] !== null) {
+					$iface['status'] = $status[0];
+				} else {
+					$iface['status'] = 'active';
+				}
 
 				if ($iface['speed'] !== null) {
 					if (strpos($iface['speed'], 'G')) {

--- a/lib/OperatingSystems/FreeBSD.php
+++ b/lib/OperatingSystems/FreeBSD.php
@@ -187,7 +187,7 @@ class FreeBSD implements IOperatingSystem {
 				$iface['status'] = $status[0];
 				$iface['speed']  = $speed[0];
 
-				if ($iface['speed'] !== '') {
+				if ($iface['speed'] !== null) {
 					if (strpos($iface['speed'], 'G')) {
 						$iface['speed'] = rtrim($iface['speed'], 'G');
 						$iface['speed'] = $iface['speed'] . ' Gbps';
@@ -198,7 +198,7 @@ class FreeBSD implements IOperatingSystem {
 					$iface['speed'] = 'unknown';
 				}
 
-				if ($duplex[0] !== '') {
+				if ($duplex[0] !== null) {
 					$iface['duplex'] = 'Duplex: ' . $duplex[0];
 				} else {
 					$iface['duplex'] = '';

--- a/lib/OperatingSystems/FreeBSD.php
+++ b/lib/OperatingSystems/FreeBSD.php
@@ -186,13 +186,13 @@ class FreeBSD implements IOperatingSystem {
 				$iface['mac'] = implode(' ', $mac[0]);
 				$iface['speed']  = $speed[0];
 
-				if ($status[0] !== null) {
+				if (isset($status[0])) {
 					$iface['status'] = $status[0];
 				} else {
 					$iface['status'] = 'active';
 				}
 
-				if ($iface['speed'] !== null) {
+				if (isset($iface['speed'])) {
 					if (strpos($iface['speed'], 'G')) {
 						$iface['speed'] = rtrim($iface['speed'], 'G');
 						$iface['speed'] = $iface['speed'] . ' Gbps';
@@ -203,7 +203,7 @@ class FreeBSD implements IOperatingSystem {
 					$iface['speed'] = 'unknown';
 				}
 
-				if ($duplex[0] !== null) {
+				if (isset($duplex[0])) {
 					$iface['duplex'] = 'Duplex: ' . $duplex[0];
 				} else {
 					$iface['duplex'] = '';


### PR DESCRIPTION
#250 

Null is returned by a pregmatch not an empty string.