### PR TITLE
Bugfix for #168: basedir restriction and handling speed=-1 result

### DIFF
--- a/lib/OperatingSystems/DefaultOs.php
+++ b/lib/OperatingSystems/DefaultOs.php
@@ -143,19 +143,19 @@ class DefaultOs implements IOperatingSystem {
 	 * @return string
 	 */
 	public function getNetworkInterfaces() {
-		$interfaces = glob('/sys/class/net/*');
+		$interfaces = array_diff(scandir("/sys/class/net"), array('.', '..'));  // remove dot directories
 		$result = [];
 
 		foreach ($interfaces as $interface) {
 			$iface              = [];
-			$iface['interface'] = basename($interface);
+			$iface['interface'] = $interface;
 			$iface['mac']       = shell_exec('ip addr show dev ' . $iface['interface'] . ' | grep "link/ether " | cut -d \' \' -f 6  | cut -f 1 -d \'/\'');
 			$iface['ipv4']      = shell_exec('ip addr show dev ' . $iface['interface'] . ' | grep "inet " | cut -d \' \' -f 6  | cut -f 1 -d \'/\'');
 			$iface['ipv6']      = shell_exec('ip -o -6 addr show ' . $iface['interface'] . ' | sed -e \'s/^.*inet6 \([^ ]\+\).*/\1/\'');
 			if ($iface['interface'] !== 'lo') {
 				$iface['status'] = shell_exec('cat /sys/class/net/' . $iface['interface'] . '/operstate');
 				$iface['speed']  = shell_exec('cat /sys/class/net/' . $iface['interface'] . '/speed');
-				if ($iface['speed'] !== '') {
+				if ($iface['speed'] !== '' and substr($iface['speed'], 0, 1) != "-") {
 					$iface['speed'] = $iface['speed'] . 'Mbps';
 				} else {
 					$iface['speed'] = 'unknown';

--- a/lib/OperatingSystems/DefaultOs.php
+++ b/lib/OperatingSystems/DefaultOs.php
@@ -143,7 +143,7 @@ class DefaultOs implements IOperatingSystem {
 	 * @return string
 	 */
 	public function getNetworkInterfaces() {
-		$interfaces = array_diff(scandir("/sys/class/net"), ['.', '..']);  // remove dot directories
+		$interfaces = array_diff(scandir('/sys/class/net'), ['.', '..']);  // remove dot directories
 		$result = [];
 
 		foreach ($interfaces as $interface) {
@@ -155,7 +155,7 @@ class DefaultOs implements IOperatingSystem {
 			if ($iface['interface'] !== 'lo') {
 				$iface['status'] = shell_exec('cat /sys/class/net/' . $iface['interface'] . '/operstate');
 				$iface['speed']  = shell_exec('cat /sys/class/net/' . $iface['interface'] . '/speed');
-				if ($iface['speed'] !== '' and substr($iface['speed'], 0, 1) != "-") {
+				if ($iface['speed'] !== '' && trim($iface['speed']) !== '-1') {
 					$iface['speed'] = $iface['speed'] . 'Mbps';
 				} else {
 					$iface['speed'] = 'unknown';

--- a/lib/OperatingSystems/DefaultOs.php
+++ b/lib/OperatingSystems/DefaultOs.php
@@ -143,7 +143,7 @@ class DefaultOs implements IOperatingSystem {
 	 * @return string
 	 */
 	public function getNetworkInterfaces() {
-		$interfaces = array_diff(scandir("/sys/class/net"), array('.', '..'));  // remove dot directories
+		$interfaces = array_diff(scandir("/sys/class/net"), ['.', '..']);  // remove dot directories
 		$result = [];
 
 		foreach ($interfaces as $interface) {


### PR DESCRIPTION
Fix for #168 with scandir instead of glob.

Minor fix for better handling `/sys/class/net/*/speed` returning `-1`.