### PR TITLE
Match any non-whitespace character in filesystem type pattern

### DIFF
--- a/lib/OperatingSystems/DefaultOs.php
+++ b/lib/OperatingSystems/DefaultOs.php
@@ -188,7 +188,7 @@ class DefaultOs implements IOperatingSystem {
 		}
 
 		$matches = [];
-		$pattern = '/^(?<Filesystem>[\S]+)\s*(?<Type>\w+)\s*(?<Blocks>\d+)\s*(?<Used>\d+)\s*(?<Available>\d+)\s*(?<Capacity>\d+%)\s*(?<Mounted>[\w\/-]+)$/m';
+		$pattern = '/^(?<Filesystem>[\S]+)\s*(?<Type>[\S]+)\s*(?<Blocks>\d+)\s*(?<Used>\d+)\s*(?<Available>\d+)\s*(?<Capacity>\d+%)\s*(?<Mounted>[\w\/-]+)$/m';
 
 		$result = preg_match_all($pattern, $disks, $matches);
 		if ($result === 0 || $result === false) {

--- a/tests/data/df_tp
+++ b/tests/data/df_tp
@@ -10,3 +10,4 @@ vagrant                                 vboxsf     958123168 614831132 343292036
 home_vagrant_code                       vboxsf     958123168 614831132 343292036      65% /home/vagrant/code
 tmpfs                                   tmpfs         816800         0    816800       0% /run/user/1000
 nfs.example.com:/export                 nfs4           14820         0      1230       0% /nfs
+198.51.100.42:/storage                  fuse.sshfs  47929956     53116  45419052       1% /mnt/sshfs

--- a/tests/lib/DefaultOsTest.php
+++ b/tests/lib/DefaultOsTest.php
@@ -174,7 +174,15 @@ class DefaultOsTest extends TestCase {
 		$disk5->setPercent('0%');
 		$disk5->setMount('/nfs');
 
-		$this->assertEquals([$disk1, $disk2, $disk3, $disk4, $disk5], $this->os->getDiskInfo());
+		$disk6 = new Disk();
+		$disk6->setDevice('198.51.100.42:/storage');
+		$disk6->setFs('fuse.sshfs');
+		$disk6->setUsed(51);
+		$disk6->setAvailable(44354);
+		$disk6->setPercent('1%');
+		$disk6->setMount('/mnt/sshfs');
+
+		$this->assertEquals([$disk1, $disk2, $disk3, $disk4, $disk5, $disk6], $this->os->getDiskInfo());
 	}
 
 	public function testGetDiskInfoNoCommandOutput(): void {


### PR DESCRIPTION
This fixes the stats for a bunch of additional filesystems: https://en.wikipedia.org/wiki/Filesystem_in_Userspace#Remote/distributed_file_system_clients
This change is based on #228.