### PR TITLE
Hide free space if it can't be calculated

### DIFF
--- a/lib/SystemStatistics.php
+++ b/lib/SystemStatistics.php
@@ -24,6 +24,7 @@ namespace OCA\ServerInfo;
 
 use OC\Files\View;
 use OC\Installer;
+use OCP\Files\FileInfo;
 use OCP\IConfig;
 use OCP\App\IAppManager;
 use bantu\IniGetWrapper\IniGetWrapper;
@@ -77,7 +78,7 @@ class SystemStatistics {
 			'filelocking.enabled' => $this->config->getSystemValue('filelocking.enabled', true) ? 'yes' : 'no',
 			'memcache.locking' => $this->config->getSystemValue('memcache.locking', 'none'),
 			'debug' => $this->config->getSystemValue('debug', false) ? 'yes' : 'no',
-			'freespace' => $this->view->free_space(),
+			'freespace' => $this->getFreeSpace(),
 			'cpuload' => $processorUsage['loadavg'],
 			'mem_total' => $memoryUsage['mem_total'],
 			'mem_free' => $memoryUsage['mem_free'],
@@ -221,5 +222,21 @@ class SystemStatistics {
 		return [
 			'loadavg' => $loadavg
 		];
+	}
+
+	/**
+	 * Get free space if it can be calculated.
+	 *
+	 * @return mixed free space or null
+	 * @throws \OCP\Files\InvalidPathException
+	 */
+	protected function getFreeSpace() {
+		$free_space = $this->view->free_space();
+		if ($free_space === FileInfo::SPACE_UNKNOWN
+			|| $free_space === FileInfo::SPACE_UNLIMITED
+			|| $free_space === FileInfo::SPACE_NOT_COMPUTED) {
+			return null;
+		}
+		return $free_space;
 	}
 }

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -151,8 +151,9 @@ $disks = $_['diskinfo'];
 
 		<p><?php p($l->t('Files:')); ?> <strong id="numFilesStorage"><?php p($_['storage']['num_files']); ?></strong></p>
 		<p><?php p($l->t('Storages:')); ?> <strong id="numFilesStorages"><?php p($_['storage']['num_storages']); ?></strong></p>
-		<p><?php p($l->t('Free Space:')); ?> <strong id="systemDiskFreeSpace"><?php p($_['system']['freespace']); ?></strong>
-		</p>
+		<?php if ($_['system']['freespace'] !== null): ?>
+			<p><?php p($l->t('Free Space:')); ?> <strong id="systemDiskFreeSpace"><?php p($_['system']['freespace']); ?></strong></p>
+		<?php endif; ?>
 	</div>
 
 	<!-- NETWORK -->


### PR DESCRIPTION
## Bug
The storage section will show `-2 B` as free space when object storage is used.

## Solution
Hide the free space section if it can not be calculated.

## Before
![free_space_before](https://user-images.githubusercontent.com/1479486/114282915-2cce3880-9a47-11eb-8440-7c346d491a03.png)

## After
![free_space_after](https://user-images.githubusercontent.com/1479486/114282916-30fa5600-9a47-11eb-9774-fd4d5f56910e.png)
