### PR TITLE
Add ratelimit to ServerInfo API endpoint

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -146,12 +146,14 @@ class ApiController extends OCSController {
 	 * @NoCSRFRequired
 	 * @NoAdminRequired
 	 * @PublicPage
+	 * @BruteForceProtection(action=serverinfo)
 	 *
 	 * @return DataResponse
 	 */
 	public function info(): DataResponse {
 		if (!$this->checkAuthorized()) {
 			$response = new DataResponse(['message' => 'Unauthorized']);
+			$response->throttle();
 			$response->setStatus(Http::STATUS_UNAUTHORIZED);
 			return $response;
 		}


### PR DESCRIPTION
This helps in case admins choose weak credentials.

Requires https://github.com/nextcloud/server/pull/27329
