### PR TITLE
List php extensions

### DIFF
--- a/lib/PhpStatistics.php
+++ b/lib/PhpStatistics.php
@@ -120,7 +120,7 @@ class PhpStatistics {
 	 * @return string as csv list of loaded extensions
 	 */
 	protected function getLoadedPhpExtensions(): string {
-		$extensions = get_loaded_extensions();
+		$extensions = (function_exists('get_loaded_extensions') ? get_loaded_extensions() : ['Unable to list extensions']);
 		return implode(', ', $extensions);
 	}
 }

--- a/lib/PhpStatistics.php
+++ b/lib/PhpStatistics.php
@@ -52,6 +52,7 @@ class PhpStatistics {
 			'upload_max_filesize' => $this->phpIni->getBytes('upload_max_filesize'),
 			'opcache' => $this->getOPcacheStatus(),
 			'apcu' => $this->getAPCuStatus(),
+			'extensions' => $this->getLoadedPhpExtensions(),
 		];
 	}
 
@@ -111,5 +112,15 @@ class PhpStatistics {
 			'cache' => $cacheInfo,
 			'sma' => $smaInfo,
 		];
+	}
+
+	/**
+	 * Get all loaded php extensions
+	 *
+	 * @return string as csv list of loaded extensions
+	 */
+	protected function getLoadedPhpExtensions(): string {
+		$extensions = get_loaded_extensions();
+		return implode(', ', $extensions);
 	}
 }

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -291,6 +291,10 @@ $disks = $_['diskinfo'];
 							<?php p($l->t('Upload max size:')); ?>
 							<em id="phpUploadMaxSize"><?php p($_['php']['upload_max_filesize']); ?></em>
 						</p>
+						<p>
+							<?php p($l->t('Extensions:')); ?>
+							<em id="phpExtensions"><?php p($_['php']['extensions']); ?></em>
+						</p>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
In many situations it's good to know which php extensions are enabled in the current setup. Usually one would look this up in `phpinfo` page but this one is not included in NC, so i thought it would be nice to add this info to the serverinfo page?