### PR TITLE
Improve gateway information parsing

### DIFF
--- a/lib/OperatingSystems/DefaultOs.php
+++ b/lib/OperatingSystems/DefaultOs.php
@@ -137,8 +137,10 @@ class DefaultOs implements IOperatingSystem {
 		$result['hostname'] = \gethostname();
 		$dns = shell_exec('cat /etc/resolv.conf |grep -i \'^nameserver\'|head -n1|cut -d \' \' -f2');
 		$result['dns'] = $dns;
-		$gw = shell_exec('ip route | awk \'/default/ { print $3 }\'');
-		$result['gateway'] = $gw;
+		$ip_route = $this->executeCommand('ip route');
+		preg_match_all("/^default.*\bvia ([[:xdigit:].:]+)\b/m", $ip_route, $matches);
+		$allgateways = implode(' ', $matches[1]);
+		$result['gateway'] = $allgateways;
 		return $result;
 	}
 

--- a/lib/OperatingSystems/FreeBSD.php
+++ b/lib/OperatingSystems/FreeBSD.php
@@ -136,8 +136,9 @@ class FreeBSD implements IOperatingSystem {
 			$alldns = implode(' ', $matches[0]);
 			$result['dns'] = $alldns;
 			$netstat = $this->executeCommand('netstat -rn');
-			preg_match("/(?<=^default).*\b\d/m", $netstat, $gw);
-			$result['gateway'] = $gw[0];
+			preg_match_all("/^default\s+([[:xdigit:].:]+)\b/m", $netstat, $matches);
+			$allgateways = implode(' ', $matches[1]);
+			$result['gateway'] = $allgateways;
 		} catch (\RuntimeException $e) {
 			return $result;
 		}


### PR DESCRIPTION
1. Fix FreeBSD-specific parsing that missed any digits
   of the last IP octet more than a single digit.
2. Support IPv6 addresses as the default gateway
3. Parse multiple default gateways in a dual-stack
   IPv4/IPv6 system
4. Switch DefaultOs.php to use `preg_match_all()`
   instead of a shell pipeline for parsing.