### PR TITLE
Update OCA\ServerInfo\OperatingSystems::getNetworkInterfaces()

### DIFF
--- a/lib/OperatingSystems/DefaultOs.php
+++ b/lib/OperatingSystems/DefaultOs.php
@@ -166,13 +166,16 @@ class DefaultOs implements IOperatingSystem {
 			$iface['ipv6']      = shell_exec('ip -o -6 addr show ' . $iface['interface'] . ' | sed -e \'s/^.*inet6 \([^ ]\+\).*/\1/\'');
 			if ($iface['interface'] !== 'lo') {
 				$iface['status'] = shell_exec('cat /sys/class/net/' . $iface['interface'] . '/operstate');
-				$iface['speed']  = shell_exec('cat /sys/class/net/' . $iface['interface'] . '/speed');
-				if (isset($iface['speed']) && $iface['speed'] !== '') {
-					$iface['speed'] = $iface['speed'] . 'Mbps';
+				$iface['speed']  = (int)shell_exec('cat /sys/class/net/' . $iface['interface'] . '/speed');
+				if (isset($iface['speed']) && $iface['speed'] > 0) {
+					if ($iface['speed'] >= 1000) {
+						$iface['speed'] = $iface['speed'] / 1000 . ' Gbps';
+					} else {
+						$iface['speed'] = $iface['speed'] . ' Mbps';
+					}
 				} else {
 					$iface['speed'] = 'unknown';
 				}
-
 				$duplex = shell_exec('cat /sys/class/net/' . $iface['interface'] . '/duplex');
 				if (isset($duplex) && $duplex !== '') {
 					$iface['duplex'] = 'Duplex: ' . $duplex;


### PR DESCRIPTION
## Change 1
Fix bug when `cat /sys/class/net/<interface>/speed` returns `-1`

![Screenshot_20211024_130122](https://user-images.githubusercontent.com/86928419/138580758-a3090694-a975-40fc-85b3-e73880b8e119.png)
![Screenshot_20211024_130511](https://user-images.githubusercontent.com/86928419/138580760-c53b6680-a356-4248-8416-36af3a85e220.png)

## Change 2
Support `Gbps` as speed unit when  `cat /sys/class/net/<interface>/speed` >= 1000
![Screenshot_20211024_131550](https://user-images.githubusercontent.com/86928419/138580761-f3cfb7e5-29bf-4308-8696-1d7ed5ad3d65.png)
Signed-off-by: Raymond Hackley <wonderfulShrineMaidenOfParadise@users.noreply.github.com>