### PR TITLE
Update PhpStatistics.php

### DIFF
--- a/lib/PhpStatistics.php
+++ b/lib/PhpStatistics.php
@@ -68,7 +68,7 @@ class PhpStatistics {
 		}
 
 		// get status information about the cache
-		//$status = opcache_get_status(false);
+		// $status = opcache_get_status(false);
 		$status = (function_exists('opcache_get_status')) ? opcache_get_status(false) : false;
 
 		if ($status === false) {

--- a/lib/PhpStatistics.php
+++ b/lib/PhpStatistics.php
@@ -68,7 +68,6 @@ class PhpStatistics {
 		}
 
 		// get status information about the cache
-		// $status = opcache_get_status(false);
 		$status = (function_exists('opcache_get_status')) ? opcache_get_status(false) : false;
 
 		if ($status === false) {

--- a/lib/PhpStatistics.php
+++ b/lib/PhpStatistics.php
@@ -68,7 +68,8 @@ class PhpStatistics {
 		}
 
 		// get status information about the cache
-		$status = opcache_get_status(false);
+		//$status = opcache_get_status(false);
+		$status = (function_exists('opcache_get_status')) ? opcache_get_status(false) : false;
 
 		if ($status === false) {
 			// no array, returning back empty array to prevent any errors on JS side.


### PR DESCRIPTION
Line 71 commented and replaced below with line 72. Based on https://help.nextcloud.com/t/20-0-1-errors-phpstatistics-opcache-get-status-has-been-disabled-for-security-reasons/97231/7 and well known issue "Return value of OCA\ServerInfo\PhpStatistics::getOPcacheStatus() must be of the type array, null returned"