### PR TITLE
Prevent PHP errors when iterating network interfaces

### DIFF
--- a/lib/OperatingSystems/DefaultOs.php
+++ b/lib/OperatingSystems/DefaultOs.php
@@ -141,7 +141,7 @@ class DefaultOs implements IOperatingSystem {
 	}
 
 	public function getNetworkInterfaces(): array {
-		$interfaces = glob('/sys/class/net/*');
+		$interfaces = glob('/sys/class/net/*') ?: [];
 		$result = [];
 
 		foreach ($interfaces as $interface) {


### PR DESCRIPTION
glob() might return false, causing "foreach() argument must be of type array|object, bool given" PHP errors