### PR TITLE
hide /etc/hostname and /etc/hosts mounts

### DIFF
--- a/lib/OperatingSystems/DefaultOs.php
+++ b/lib/OperatingSystems/DefaultOs.php
@@ -199,6 +199,8 @@ class DefaultOs implements IOperatingSystem {
 		foreach ($matches['Filesystem'] as $i => $filesystem) {
 			if (in_array($matches['Type'][$i], ['tmpfs', 'devtmpfs', 'squashfs', 'overlay'], false)) {
 				continue;
+			} elseif (in_array($matches['Mounted'][$i], ['/etc/hostname', '/etc/hosts'], false)) {
+				continue;
 			}
 
 			$disk = new Disk();


### PR DESCRIPTION
Resolve https://help.nextcloud.com/t/why-is-a-disk-mounted-multiple-times-inside-my-docker-container/144075/2

Signed-off-by: szaimen <szaimen@e.mail.de>

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/42591237/185732049-da47f6b1-a1b8-478d-81a2-b665af011a43.png) | ![image](https://user-images.githubusercontent.com/42591237/185731980-e346678e-3cdf-4eaa-a56e-db62f0769aaf.png) |