### PR TITLE
Space between diskchart and info text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -56,6 +56,7 @@
 
 .diskchart-container {
 	width: 100px;
+	margin-right: 25px;
 	border: 1px var(--color-border);
 }
 


### PR DESCRIPTION
Added some space between the diskchart and info text

Signed-off-by: Dennis1993 <Dennis1993@users.noreply.github.com>


Before:
![image](https://user-images.githubusercontent.com/1473674/188309554-9fd87b4a-9209-431b-9242-5ef27ebb760c.png)

After:
![image](https://user-images.githubusercontent.com/1473674/188309535-9de0dadd-c44f-4da7-8fca-ed8d865456c8.png)

Mobile view:
![image](https://user-images.githubusercontent.com/1473674/188309590-e5577b3e-92ea-40ba-bdb5-14fa76a89dfb.png)
