### PR TITLE
[stable23] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -383,12 +383,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "74fa82bb013bb329eb59b18d6eb94a660d724fea"
+                "reference": "5b18c55569528d8190224af04095e9dde1953c72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/74fa82bb013bb329eb59b18d6eb94a660d724fea",
-                "reference": "74fa82bb013bb329eb59b18d6eb94a660d724fea",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5b18c55569528d8190224af04095e9dde1953c72",
+                "reference": "5b18c55569528d8190224af04095e9dde1953c72",
                 "shasum": ""
             },
             "require": {
@@ -415,9 +415,10 @@
             ],
             "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
             "support": {
+                "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable23"
             },
-            "time": "2022-08-23T02:31:53+00:00"
+            "time": "2022-12-20T00:37:08+00:00"
         },
         {
             "name": "paragonie/random_compat",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency