### PR TITLE
Relevant disks filtering (from nextcloud paths)

### DIFF
--- a/lib/OperatingSystems/DefaultOs.php
+++ b/lib/OperatingSystems/DefaultOs.php
@@ -209,6 +209,17 @@ class DefaultOs implements IOperatingSystem {
 			} elseif (in_array($matches['Mounted'][$i], ['/etc/hostname', '/etc/hosts'], false)) {
 				continue;
 			}
+			
+			// Filter system option: only relevant disks (mount point parent of html or data directory)
+			if (\OC::$server->getSystemConfig()->getValue('serverinfo.filter_disks', false)) {
+				$len = strlen($matches['Mounted'][$i]);
+				if (strncmp(__DIR__, $matches['Mounted'][$i], $len) !== 0) {
+					$datadir = \OC::$server->getSystemConfig()->getValue('datadirectory', '');
+					if (strncmp($datadir, $matches['Mounted'][$i], $len) !== 0) {
+						continue;
+					}
+				}
+			}
 
 			$disk = new Disk();
 			$disk->setDevice($filesystem);

--- a/lib/OperatingSystems/FreeBSD.php
+++ b/lib/OperatingSystems/FreeBSD.php
@@ -207,6 +207,17 @@ class FreeBSD implements IOperatingSystem {
 				continue;
 			}
 
+			// Filter system option: only relevant disks (mount point parent of html or data directory)
+			if (\OC::$server->getSystemConfig()->getValue('serverinfo.filter_disks', false)) {
+				$len = strlen($matches['Mounted'][$i]);
+				if (strncmp(__DIR__, $matches['Mounted'][$i], $len) !== 0) {
+					$datadir = \OC::$server->getSystemConfig()->getValue('datadirectory', '');
+					if (strncmp($datadir, $matches['Mounted'][$i], $len) !== 0) {
+						continue;
+					}
+				}
+			}
+			
 			$disk = new Disk();
 			$disk->setDevice($filesystem);
 			$disk->setFs($matches['Type'][$i]);


### PR DESCRIPTION
Another disks filter:
- optional: only if activated from the system config (new key `serverinfo.filter_disks`)
- simple to configure: just a boolean value (off by default)
- automatic relevance determination if the disks mount point is parent of the Nextcloud instance (html or data directory)

Reference #381
