### PR TITLE
fix Undefined Array key Family in DefaultOs

### DIFF
--- a/lib/OperatingSystems/DefaultOs.php
+++ b/lib/OperatingSystems/DefaultOs.php
@@ -153,11 +153,13 @@ class DefaultOs implements IOperatingSystem {
 			$data[] = $netInterface;
 
 			foreach ($interface['unicast'] as $unicast) {
-				if ($unicast['family'] === self::AF_INET) {
-					$netInterface->addIPv4($unicast['address']);
-				}
-				if ($unicast['family'] === self::AF_INET6) {
-					$netInterface->addIPv6($unicast['address']);
+				if (isset($unicast['family'])) {
+					if ($unicast['family'] === self::AF_INET) {
+						$netInterface->addIPv4($unicast['address']);
+					}
+					if ($unicast['family'] === self::AF_INET6) {
+						$netInterface->addIPv6($unicast['address']);
+					}
 				}
 			}
 


### PR DESCRIPTION
resolves #435

It seems like some interfaces (like `wg0` which is created by Wireguard) don't have a `family` array key associated to them.