### PR TITLE
With FreeBSD jails, networkinfo->gateway can be empty

### DIFF
--- a/lib/OperatingSystems/FreeBSD.php
+++ b/lib/OperatingSystems/FreeBSD.php
@@ -126,6 +126,8 @@ class FreeBSD implements IOperatingSystem {
 			preg_match_all("/(?<=^default)\s*[0-9a-fA-f\.:]+/m", $netstat, $gw);
 			if (count($gw[0]) > 0) {
 				$result['gateway'] = implode(", ", array_map("trim", $gw[0]));
+			} else {
+				$result['gateway'] = '';
 			}
 		} catch (RuntimeException $e) {
 			return $result;


### PR DESCRIPTION
When installed in a FreeBSD jail, this error appears in logs:
`Undefined array key "gateway" at /path/to/nextcloud/apps/serverinfo/templates/settings-admin.php#199`

The patch defines the array key with an empty string.