### PR TITLE
Use the color-primary-element* variables

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -73,7 +73,7 @@
 }
 
 .info-color-label--used::before {
-	background-color: var(--color-primary);
+	background-color: var(--color-primary-element);
 }
 
 @media only screen and (max-width: $breakpoint-mobile) {


### PR DESCRIPTION
Explanation: the color-primary variables are not to be used in components because the introduce problems with high-contrast primary colors. Fix this by using the primary-element variables instead.