### PR TITLE
Get system date/time without needing shell_exec()

### DIFF
--- a/lib/OperatingSystems/DefaultOs.php
+++ b/lib/OperatingSystems/DefaultOs.php
@@ -120,7 +120,7 @@ class DefaultOs implements IOperatingSystem {
 	}
 
 	public function getTime(): string {
-		return (string)shell_exec('date');
+		return date("D M j G:i:s T Y");
 	}
 
 	public function getUptime(): int {


### PR DESCRIPTION
One less use of shell_exec(). Maintains same output format typically used by `date` so no changes needed elsewhere.

Relevant to #169 and possibly #347.

It's also about 200x faster per call according to benchmarking via PHP's hrtime() on my test system, but that's 100% irrelevant unless one has _a lot_ of admins checking their System info simultaneously. 😆