### PR TITLE
Update settings-admin.php to add Exabyte

### DIFF
--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -34,7 +34,7 @@ script('serverinfo', 'Chart.min');
 style('serverinfo', 'style');
 
 function FormatMegabytes(int $byte): string {
-	$unim = ['MB', 'GB', 'TB', 'PB'];
+	$unim = ['MB', 'GB', 'TB', 'PB', 'EB'];
 	$count = 0;
 	while ($byte >= 1024) {
 		$count++;


### PR DESCRIPTION
When using Elastic File Storage on AWS as a shared filesystem AWS reports the size as 8 exabytes. However, serverinfo is currently limited to petabytes when displaying volume sizes. This PR is supposed to fix it.