### PR TITLE
Display the current opcache.revalidate_freq setting under PHP details

### DIFF
--- a/lib/PhpStatistics.php
+++ b/lib/PhpStatistics.php
@@ -45,6 +45,10 @@ class PhpStatistics {
 			'memory_limit' => $this->phpIni->getBytes('memory_limit'),
 			'max_execution_time' => $this->phpIni->getNumeric('max_execution_time'),
 			'upload_max_filesize' => $this->phpIni->getBytes('upload_max_filesize'),
+			'opcache_revalidate_freq' => $this->phpIni->getNumeric('opcache.revalidate_freq'),
+			// NOTE: If access to add'l OPcache *config* parameters is desired consider
+			//   implementing a getOPcacheConfig() wrapper for PHP's opcache_get_configuration()
+			//   like we do for PHP's opcache_get_status() already below
 			'opcache' => $this->getOPcacheStatus(),
 			'apcu' => $this->getAPCuStatus(),
 			'extensions' => $this->getLoadedPhpExtensions(),

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -356,6 +356,10 @@ $interfaces = $_['networkinterfaces'];
 						<p>
 							<?php p($l->t('Upload max size:')); ?>
 							<em id="phpUploadMaxSize"><?php p($_['php']['upload_max_filesize']); ?></em>
+						</p>                                               
+						<p>
+							<?php p($l->t('OPcache Revalidate Frequency:')); ?>
+							<em id="phpOpcacheRevalidateFreq"><?php p($_['php']['opcache_revalidate_freq']); ?></em>
 						</p>
 						<p>
 							<?php p($l->t('Extensions:')); ?>


### PR DESCRIPTION
Adds the current `opcache.revalidate_freq` setting under the existing PHP details section.

This parameter is officially documented in the Server Tuning manual of the Nextcloud Admin Manual, but no specific number is enforced within Nextcloud:

https://docs.nextcloud.com/server/latest/admin_manual/installation/server_tuning.html?highlight=revalidate_freq#enable-php-opcache
<img width="512" alt="NC Serverinfo - OPcache Revalidate Freq - Screenshot 2023-05-15 165515" src="https://github.com/nextcloud/serverinfo/assets/1731941/313688aa-a6b6-4175-affa-39fa17858bb6">

Context: The parameter can impact performance (sometimes) and how often changes are propagated (most notably `config.php` adjustments).

P.S. The yellow is just for the screenshot - it's not in the patch