### PR TITLE
Display full path(s) to currently active php .ini files

### DIFF
--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -365,6 +365,10 @@ $interfaces = $_['networkinterfaces'];
 							<?php p($l->t('Extensions:')); ?>
 							<em id="phpExtensions"><?php p($_['php']['extensions'] !== null ? implode(', ', $_['php']['extensions']) : $l->t('Unable to list extensions')); ?></em>
 						</p>
+						<p>
+							<?php p($l->t('Active PHP .ini files:')); ?>
+							<em id="phpLoadedIniFiles"><?php p($_['php']['php_ini_files'] !== null ? implode(', ', $_['php']['php_ini_files']) : $l->t('Unable to list .ini files')); ?></em>
+						</p>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Helps people figure out which PHP ini file(s) are truly being used by their active NC installation

* Displays the full path(s) to the currently loaded `php.ini` file (if any) along with any other PHP configuration files parsed after `php.ini` (i.e. from additional compiled in paths or provided by the environment at run time).
* Furthers #362 and #107
* Desirable for:
  - Server Tuning
  - [Troubleshooting Web server and PHP problems
](https://docs.nextcloud.com/server/latest/admin_manual/issues/general_troubleshooting.html#troubleshooting-web-server-and-php-problems)
  - Upgrades
  - Migrations
  - Hardening and Security guidance
  - etc.

<img width="919" alt="NC ServerInfo - Active PHP ini Files PR - Screenshot 2023-05-31 123228" src="https://github.com/nextcloud/serverinfo/assets/1731941/5527d3f7-f1b9-4beb-9785-52d0a0751b53">

(yellow just for screenshot)