### PR TITLE
Check for sys_getloadavg() rather than triggering an exception

### DIFF
--- a/lib/SystemStatistics.php
+++ b/lib/SystemStatistics.php
@@ -134,8 +134,8 @@ class SystemStatistics {
 	 * @return array{loadavg: array|string} load average with three values, 1/5/15 minutes average.
 	 */
 	protected function getProcessorUsage(): array {
-		// get current system load average.
-		$loadavg = sys_getloadavg();
+		// get current system load average - if we can
+		$loadavg = (function_exists('sys_getloadavg')) ? sys_getloadavg() : false;
 
 		// check if we got any values back.
 		if ($loadavg === false || count($loadavg) !== 3) {


### PR DESCRIPTION
Fixes #337

Also fixes reports of the same issue that have appeared indirectly elsewhere - e.g.:
* https://github.com/nextcloud/server/issues/26374#issuecomment-851495070
* https://github.com/nextcloud/server/issues/25692#issuecomment-780548165