### PR TITLE
[stable26] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -721,12 +721,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "e96e5a5b17fc30e79d59091ccf1356e93816e5b7"
+                "reference": "0dbe7e45ba027b4393cb92845251b4cec1b39355"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e96e5a5b17fc30e79d59091ccf1356e93816e5b7",
-                "reference": "e96e5a5b17fc30e79d59091ccf1356e93816e5b7",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/0dbe7e45ba027b4393cb92845251b4cec1b39355",
+                "reference": "0dbe7e45ba027b4393cb92845251b4cec1b39355",
                 "shasum": ""
             },
             "require": {
@@ -756,7 +756,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable26"
             },
-            "time": "2023-06-17T00:37:14+00:00"
+            "time": "2023-07-11T00:39:09+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency