### PR TITLE
chore: remove dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,15 +14,3 @@ updates:
     commit-message:
       prefix: chore
       include: scope
-
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: weekly
-      day: saturday
-      time: "03:00"
-      timezone: Europe/Paris
-    open-pull-requests-limit: 10
-    commit-message:
-      prefix: chore
-      include: scope


### PR DESCRIPTION
The actions are updated via organization template repository :see_no_evil: 