### PR TITLE
chore: add value object for thermal zone

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -293,8 +293,8 @@
 					var data = response.ocs.data;
 					document.getElementById("servertime").innerHTML = data.servertime;
 					document.getElementById("uptime").innerHTML = data.uptime;
-					for (i in data.thermalzones) {
-						document.getElementById(data.thermalzones[i]['hash']).innerHTML = data.thermalzones[i]['temp'];
+					for (const thermalzone of data.thermalzones) {
+						document.getElementById(thermalzone.zone).textContent = thermalzone.temp;
 					}
 				},
 				error: function (data) {

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -138,12 +138,11 @@ class ApiController extends OCSController {
 	public function BasicData(): DataResponse {
 		$servertime = $this->os->getTime();
 		$uptime = $this->formatUptime($this->os->getUptime());
-		$thermalzones = $this->os->getThermalZones();
 
 		return new DataResponse([
 			'servertime' => $servertime,
 			'uptime' => $uptime,
-			'thermalzones' => $thermalzones
+			'thermalzones' => $this->os->getThermalZones()
 		]);
 	}
 

--- a/lib/OperatingSystems/IOperatingSystem.php
+++ b/lib/OperatingSystems/IOperatingSystem.php
@@ -29,6 +29,7 @@ namespace OCA\ServerInfo\OperatingSystems;
 use OCA\ServerInfo\Resources\Disk;
 use OCA\ServerInfo\Resources\Memory;
 use OCA\ServerInfo\Resources\NetInterface;
+use OCA\ServerInfo\Resources\ThermalZone;
 
 interface IOperatingSystem {
 	public function supported(): bool;
@@ -86,13 +87,7 @@ interface IOperatingSystem {
 	/**
 	 * Get info about available thermal zones.
 	 *
-	 * [
-	 *       [
-	 *             'hash' => string,
-	 *             'type' => string,
-	 *             'temp' => float,
-	 *       ],
-	 * ]
+	 * @return ThermalZone[]
 	 */
 	public function getThermalZones(): array;
 }

--- a/lib/Resources/ThermalZone.php
+++ b/lib/Resources/ThermalZone.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\ServerInfo\Resources;
+
+class ThermalZone implements \JsonSerializable {
+	public function __construct(
+		private string $zone,
+		private string $type,
+		private float  $temp) {
+	}
+
+	public function getZone(): string {
+		return $this->zone;
+	}
+
+	public function getType(): string {
+		return $this->type;
+	}
+
+	public function getTemp(): float {
+		return $this->temp;
+	}
+
+	public function jsonSerialize(): array {
+		return [
+			'zone' => $this->zone,
+			'type' => $this->type,
+			'temp' => $this->temp,
+		];
+	}
+}

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 use OCA\ServerInfo\Resources\Disk;
 use OCA\ServerInfo\Resources\Memory;
 use OCA\ServerInfo\Resources\NetInterface;
+use OCA\ServerInfo\Resources\ThermalZone;
 use OCP\Util;
 
 script('serverinfo', 'script');
@@ -51,6 +52,8 @@ $memory = $_['memory'];
 $disks = $_['diskinfo'];
 /** @var NetInterface[] $interfaces */
 $interfaces = $_['networkinterfaces'];
+/** @var ThermalZone[] $thermalZones */
+$thermalZones = $_['thermalzones'];
 /** @var bool $phpinfo */
 $phpinfo = $_['phpinfo'];
 
@@ -80,6 +83,7 @@ $phpinfo = $_['phpinfo'];
 				<p><?php p($l->t('Uptime:')); ?> <strong id="numFilesStorage"><span class="info" id="uptime"></span></strong></p>
 			</div>
 
+			<?php if (count($thermalZones) > 0): ?>
 			<div class="col col-6 col-l-12">
 				<h2>
 					<img class="infoicon" src="<?php p(image_path('serverinfo', 'app-dark.svg')); ?>">
@@ -90,16 +94,17 @@ $phpinfo = $_['phpinfo'];
 						<thead>
 						</thead>
 						<tbody>
-						<?php foreach ($_['thermalzones'] as $thermalzone): ?>
+						<?php foreach ($thermalZones as $thermalZone): ?>
 						<tr>
-							<td><?php p($thermalzone['type'] . ':') ?></td>
-							<td><span class="info" id="<?php p($thermalzone['hash']) ?>"></span>°C</td>
+							<td><?php p($thermalZone->getType()) ?>:</td>
+							<td>&nbsp;<span class="info" id="<?php p($thermalZone->getZone()) ?>"><?php p($thermalZone->getTemp()) ?></span>°C</td>
 						</tr>
 						<?php endforeach; ?>
 						</tbody>
 					</table>
 				</div>
 			</div>
+			<?php endif; ?>
 		</div>
 	</div>
 


### PR DESCRIPTION
Notable change:

The temperatur heading is hidden, when no thermal zones are found. 