### PR TITLE
fix: add flag to skip external requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ directory **nextcloud/apps/serverinfo**
 
 ## API
 
-The API provides a lot of information information about a running Nextcloud
-instance in XML or JSON format, by using the following URL. If you want to
-get the information returned in JSON format, you have to append **`?format=json`**
-to the URL.
+The API provides a lot of information about a running Nextcloud
+instance in XML or JSON format by using the following URL.
+
 ```
 https://<nextcloud-fqdn>/ocs/v2.php/apps/serverinfo/api/v1/info
 ```
+
+- To request the information in JSON append the url parameter `format=json`
+- Use the url parameter `skipUpdate=true` to omit server updates.
+- Use the url parameter `skipApps=true` to omit app updates (including available app updates will send an external request to the app store).
 
 ### Example XML output:
 ```

--- a/css/style.css
+++ b/css/style.css
@@ -244,3 +244,14 @@
 	}
 }
 */
+
+.monitoring-url-params {
+	margin-top: 3px;
+	margin-bottom: 3px;
+}
+
+.monitoring-url-param {
+	display: flex;
+	align-items: center;
+	height: 24px;
+}

--- a/js/script.js
+++ b/js/script.js
@@ -225,7 +225,7 @@
 	function initMonitoringLinkToClipboard() {
 		var clipboard = new Clipboard('.clipboardButton');
 		clipboard.on('success', function (e) {
-			OC.Notification.show('Copied!', { type: 'success' })
+			OC.Notification.show(t('serverinfo', 'Copied!'), { type: 'success' })
 		});
 		clipboard.on('error', function () {
 			var actionMsg = '';

--- a/js/script.js
+++ b/js/script.js
@@ -310,3 +310,32 @@
 	}
 
 })(jQuery, OC);
+
+function updateMonitoringUrl(event) {
+	const $endpointUrl = document.getElementById('monitoring-endpoint-url');
+	const $params = document.querySelectorAll('.update-monitoring-endpoint-url');
+
+	const url = new URL($endpointUrl.value)
+	url.searchParams.delete('format')
+	url.searchParams.delete('skipUpdate')
+	url.searchParams.delete('skipApps')
+
+	for (const $param of $params) {
+		if ($param.name === 'format_json' && $param.checked) {
+			url.searchParams.set('format', 'json')
+		}
+		if ($param.name === 'skip_update' && $param.checked) {
+			url.searchParams.set('skipUpdate', 'true')
+		}
+		if ($param.name === 'skip_apps' && $param.checked) {
+			url.searchParams.set('skipApps', 'true')
+		}
+	}
+
+	$endpointUrl.value = url.toString()
+}
+
+document.addEventListener('DOMContentLoaded', function (event) {
+	const $params = document.querySelectorAll('.update-monitoring-endpoint-url');
+	$params.forEach($param => $param.addEventListener('change', updateMonitoringUrl));
+});

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -113,7 +113,7 @@ class ApiController extends OCSController {
 	 * @PublicPage
 	 * @BruteForceProtection(action=serverinfo)
 	 */
-	public function info(): DataResponse {
+	public function info(bool $skipUpdate = false, bool $skipApps = false): DataResponse {
 		if (!$this->checkAuthorized()) {
 			$response = new DataResponse(['message' => 'Unauthorized']);
 			$response->throttle();
@@ -122,7 +122,7 @@ class ApiController extends OCSController {
 		}
 		return new DataResponse([
 			'nextcloud' => [
-				'system' => $this->systemStatistics->getSystemStatistics(),
+				'system' => $this->systemStatistics->getSystemStatistics($skipUpdate, $skipApps),
 				'storage' => $this->storageStatistics->getStorageStatistics(),
 				'shares' => $this->shareStatistics->getShareStatistics()
 			],

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -47,7 +47,7 @@ class PageController extends Controller {
 	 */
 	public function update(): JSONResponse {
 		$data = [
-			'system' => $this->systemStatistics->getSystemStatistics()
+			'system' => $this->systemStatistics->getSystemStatistics(true, true)
 		];
 
 		return new JSONResponse($data);

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -87,7 +87,7 @@ class AdminSettings implements ISettings {
 			'php' => $this->phpStatistics->getPhpStatistics(),
 			'database' => $this->databaseStatistics->getDatabaseStatistics(),
 			'activeUsers' => $this->sessionStatistics->getSessionStatistics(),
-			'system' => $this->systemStatistics->getSystemStatistics(),
+			'system' => $this->systemStatistics->getSystemStatistics(true, true),
 			'thermalzones' => $this->os->getThermalZones(),
 			'phpinfo' => $this->config->getAppValue('serverinfo', 'phpinfo', 'no') === 'yes',
 			'phpinfoUrl' => $this->urlGenerator->linkToRoute('serverinfo.page.phpinfo')

--- a/lib/SystemStatistics.php
+++ b/lib/SystemStatistics.php
@@ -51,12 +51,12 @@ class SystemStatistics {
 	 *
 	 * @throws \OCP\Files\InvalidPathException
 	 */
-	public function getSystemStatistics(): array {
+	public function getSystemStatistics(bool $skipUpdate = false, bool $skipApps = false): array {
 		$processorUsage = $this->getProcessorUsage();
 		$memoryUsage = $this->os->getMemory();
-		return [
+
+		$data = [
 			'version' => $this->config->getSystemValue('version'),
-			'update' => $this->getServerUpdateInfo(),
 			'theme' => $this->config->getSystemValue('theme', 'none'),
 			'enable_avatars' => $this->config->getSystemValue('enable_avatars', true) ? 'yes' : 'no',
 			'enable_previews' => $this->config->getSystemValue('enable_previews', true) ? 'yes' : 'no',
@@ -71,8 +71,17 @@ class SystemStatistics {
 			'mem_free' => $memoryUsage->getMemAvailable() * 1024,
 			'swap_total' => $memoryUsage->getSwapTotal() * 1024,
 			'swap_free' => $memoryUsage->getSwapFree() * 1024,
-			'apps' => $this->getAppsInfo()
 		];
+
+		if (!$skipUpdate) {
+			$data['update'] = $this->getServerUpdateInfo();
+		}
+
+		if (!$skipApps) {
+			$data['apps'] = $this->getAppsInfo();
+		}
+
+		return $data;
 	}
 
 	/**

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -412,15 +412,28 @@ $phpinfo = $_['phpinfo'];
 				<!-- OCS ENDPOINT -->
 				<h2><?php p($l->t('External monitoring tool')); ?></h2>
 				<p>
-					<?php p($l->t('You can connect an external monitoring tool by using this end point:')); ?>
+					<?php p($l->t('Use this end point to connect an external monitoring tool:')); ?>
 				</p>
 				<div class="monitoring-wrapper">
 					<input type="text" readonly="readonly" id="monitoring-endpoint-url" value="<?php echo p($_['ocs']); ?>"/>
 					<a class="clipboardButton icon icon-clippy" title="<?php p($l->t('Copy')); ?>" aria-label="<?php p($l->t('Copy')); ?>" data-clipboard-target="#monitoring-endpoint-url"></a>
 				</div>
-				<p class="settings-hint">
-					<?php p($l->t('Appending "?format=json" at the end of the URL gives you the result in JSON.')); ?>
-				</p>
+
+				<div class="monitoring-url-params">
+					<div class="monitoring-url-param">
+						<input type="checkbox" class="update-monitoring-endpoint-url" name="format_json" id="format_json">
+						<label for="format_json"><?php p($l->t('Output in JSON')) ?></label>
+					</div>
+					<div class="monitoring-url-param">
+						<input type="checkbox" class="update-monitoring-endpoint-url" name="skip_update" id="skip_update">
+						<label for="skip_update"><?php p($l->t('Skip server update')) ?></label>
+					</div>
+					<div class="monitoring-url-param">
+						<input type="checkbox" class="update-monitoring-endpoint-url" name="skip_apps" id="skip_apps">
+						<label for="skip_apps"><?php p($l->t('Skip app updates (including app updates will send an external request to the app store)')) ?></label>
+					</div>
+				</div>
+
 				<p>
 					<?php p($l->t('To use an access token, please generate one then set it using the following command:')); ?>
 					<div><i>occ config:app:set serverinfo token --value yourtoken</i></div>


### PR DESCRIPTION
For https://github.com/nextcloud/serverinfo/issues/503
Fix https://github.com/nextcloud/serverinfo/issues/343

Collecting available app updates will always send at least one http request to the apps store. 

This pull requests will add a flag to omit server and/or app updates.

The default is to include updates to not break existing usages.