### PR TITLE
feat: make update data opt-in

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -317,18 +317,18 @@ function updateMonitoringUrl(event) {
 
 	const url = new URL($endpointUrl.value)
 	url.searchParams.delete('format')
-	url.searchParams.delete('skipUpdate')
 	url.searchParams.delete('skipApps')
+	url.searchParams.delete('skipUpdate')
 
 	for (const $param of $params) {
 		if ($param.name === 'format_json' && $param.checked) {
 			url.searchParams.set('format', 'json')
 		}
-		if ($param.name === 'skip_update' && $param.checked) {
-			url.searchParams.set('skipUpdate', 'true')
-		}
 		if ($param.name === 'skip_apps' && $param.checked) {
 			url.searchParams.set('skipApps', 'true')
+		}
+		if ($param.name === 'skip_update' && !$param.checked) {
+			url.searchParams.set('skipUpdate', 'false')
 		}
 	}
 

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -113,7 +113,7 @@ class ApiController extends OCSController {
 	 * @PublicPage
 	 * @BruteForceProtection(action=serverinfo)
 	 */
-	public function info(bool $skipUpdate = false, bool $skipApps = false): DataResponse {
+	public function info(bool $skipApps = false, bool $skipUpdate = true): DataResponse {
 		if (!$this->checkAuthorized()) {
 			$response = new DataResponse(['message' => 'Unauthorized']);
 			$response->throttle();
@@ -122,7 +122,7 @@ class ApiController extends OCSController {
 		}
 		return new DataResponse([
 			'nextcloud' => [
-				'system' => $this->systemStatistics->getSystemStatistics($skipUpdate, $skipApps),
+				'system' => $this->systemStatistics->getSystemStatistics($skipApps, $skipUpdate),
 				'storage' => $this->storageStatistics->getStorageStatistics(),
 				'shares' => $this->shareStatistics->getShareStatistics()
 			],

--- a/lib/SystemStatistics.php
+++ b/lib/SystemStatistics.php
@@ -51,7 +51,7 @@ class SystemStatistics {
 	 *
 	 * @throws \OCP\Files\InvalidPathException
 	 */
-	public function getSystemStatistics(bool $skipUpdate = false, bool $skipApps = false): array {
+	public function getSystemStatistics(bool $skipApps = false, bool $skipUpdate = true): array {
 		$processorUsage = $this->getProcessorUsage();
 		$memoryUsage = $this->os->getMemory();
 
@@ -73,12 +73,12 @@ class SystemStatistics {
 			'swap_free' => $memoryUsage->getSwapFree() * 1024,
 		];
 
-		if (!$skipUpdate) {
-			$data['update'] = $this->getServerUpdateInfo();
-		}
-
 		if (!$skipApps) {
 			$data['apps'] = $this->getAppsInfo();
+		}
+
+		if (!$skipUpdate) {
+			$data['update'] = $this->getServerUpdateInfo();
 		}
 
 		return $data;

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -425,12 +425,12 @@ $phpinfo = $_['phpinfo'];
 						<label for="format_json"><?php p($l->t('Output in JSON')) ?></label>
 					</div>
 					<div class="monitoring-url-param">
-						<input type="checkbox" class="update-monitoring-endpoint-url" name="skip_update" id="skip_update">
-						<label for="skip_update"><?php p($l->t('Skip server update')) ?></label>
-					</div>
-					<div class="monitoring-url-param">
 						<input type="checkbox" class="update-monitoring-endpoint-url" name="skip_apps" id="skip_apps">
 						<label for="skip_apps"><?php p($l->t('Skip app updates (including app updates will send an external request to the app store)')) ?></label>
+					</div>
+					<div class="monitoring-url-param">
+						<input type="checkbox" class="update-monitoring-endpoint-url" name="skip_update" id="skip_update" checked>
+						<label for="skip_update"><?php p($l->t('Skip server update')) ?></label>
 					</div>
 				</div>
 


### PR DESCRIPTION
The update section is new in Nextcloud 28, and therefore it's still possible to change the default to false.

fyi @peschmae the feature is now opt-in.