### PR TITLE
Use a more sensible format for load average

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -111,7 +111,7 @@
 			});
 		}
 
-		$cpuFooterInfo.text(t('serverinfo', 'Load average: {cpu} (last minute)', { cpu: cpu1 }));
+		$cpuFooterInfo.text(t('serverinfo', 'Load average: {cpu} (last minute)', { cpu: cpu1.toFixed(2) }));
 		cpuLoadLine.append(new Date().getTime(), cpu1);
 	}
 


### PR DESCRIPTION
The umpteen digits of precision in the default format are quite useless, even `uptime` shows only two decimal places. This makes it look a lot more sensible.