### PR TITLE
fix: Display threads and not cores

### DIFF
--- a/lib/OperatingSystems/FreeBSD.php
+++ b/lib/OperatingSystems/FreeBSD.php
@@ -62,12 +62,12 @@ class FreeBSD implements IOperatingSystem {
 
 		try {
 			$model = $this->executeCommand('/sbin/sysctl -n hw.model');
-			$cores = $this->executeCommand('/sbin/sysctl -n kern.smp.cpus');
+			$threads = $this->executeCommand('/sbin/sysctl -n kern.smp.cpus');
 
-			if ((int)$cores === 1) {
-				$data = $model . ' (1 core)';
+			if ((int)$threads === 1) {
+				$data = $model . ' (1 thread)';
 			} else {
-				$data = $model . ' (' . $cores . ' cores)';
+				$data = $model . ' (' . $threads . ' threads)';
 			}
 		} catch (RuntimeException $e) {
 			return $data;

--- a/lib/OperatingSystems/Linux.php
+++ b/lib/OperatingSystems/Linux.php
@@ -95,12 +95,12 @@ class Linux implements IOperatingSystem {
 		$pattern = '/processor\s+:\s(.+)/';
 
 		preg_match_all($pattern, $cpuinfo, $matches);
-		$cores = count($matches[1]);
+		$threads = count($matches[1]);
 
-		if ($cores === 1) {
-			$data = $model . ' (1 core)';
+		if ($threads === 1) {
+			$data = $model . ' (1 thread)';
 		} else {
-			$data = $model . ' (' . $cores . ' cores)';
+			$data = $model . ' (' . $threads . ' threads)';
 		}
 
 		return $data;

--- a/tests/lib/LinuxTest.php
+++ b/tests/lib/LinuxTest.php
@@ -68,7 +68,7 @@ class LinuxTest extends TestCase {
 			->with('/proc/cpuinfo')
 			->willReturn(file_get_contents(__DIR__ . '/../data/linux_cpuinfo'));
 
-		$this->assertEquals('Intel(R) Core(TM) i5-6500 CPU @ 3.20GHz (4 cores)', $this->os->getCpuName());
+		$this->assertEquals('Intel(R) Core(TM) i5-6500 CPU @ 3.20GHz (4 threads)', $this->os->getCpuName());
 	}
 
 	public function testGetCpuNameOneCore(): void {
@@ -76,7 +76,7 @@ class LinuxTest extends TestCase {
 			->with('/proc/cpuinfo')
 			->willReturn(file_get_contents(__DIR__ . '/../data/linux_cpuinfo_one_core'));
 
-		$this->assertEquals('Intel(R) Core(TM) i5-6500 CPU @ 3.20GHz (1 core)', $this->os->getCpuName());
+		$this->assertEquals('Intel(R) Core(TM) i5-6500 CPU @ 3.20GHz (1 thread)', $this->os->getCpuName());
 	}
 
 	public function testGetCpuNamePi3b(): void {
@@ -84,7 +84,7 @@ class LinuxTest extends TestCase {
 			->with('/proc/cpuinfo')
 			->willReturn(file_get_contents(__DIR__ . '/../data/linux_cpuinfo_pi3b'));
 
-		$this->assertEquals('Raspberry Pi 3 Model B Rev 1.2 (4 cores)', $this->os->getCpuName());
+		$this->assertEquals('Raspberry Pi 3 Model B Rev 1.2 (4 threads)', $this->os->getCpuName());
 	}
 
 	public function testGetCpuNamePi4b(): void {
@@ -92,7 +92,7 @@ class LinuxTest extends TestCase {
 			->with('/proc/cpuinfo')
 			->willReturn(file_get_contents(__DIR__ . '/../data/linux_cpuinfo_pi4b'));
 
-		$this->assertEquals('Raspberry Pi 4 Model B Rev 1.2 (4 cores)', $this->os->getCpuName());
+		$this->assertEquals('Raspberry Pi 4 Model B Rev 1.2 (4 threads)', $this->os->getCpuName());
 	}
 
 	public function testGetCpuNameOpenPower(): void {
@@ -100,7 +100,7 @@ class LinuxTest extends TestCase {
 			->with('/proc/cpuinfo')
 			->willReturn(file_get_contents(__DIR__ . '/../data/linux_cpuinfo_openpower'));
 
-		$this->assertEquals('POWER9, altivec supported (176 cores)', $this->os->getCpuName());
+		$this->assertEquals('POWER9, altivec supported (176 threads)', $this->os->getCpuName());
 	}
 
 	public function testGetCpuNameNoData(): void {


### PR DESCRIPTION
For Linux I verified this is correct, but I'm not able to test this on FreeBSD. I'm relatively sure though that the variable that is read is also the thread count and not the core count.
While trying to find documentation for the sysctl variable I read https://man.freebsd.org/cgi/man.cgi?smp(4) and it seems we should switch to `hw.ncpu` since that is at least documented (and if I understood correctly it is also the thread count and not the core count).
On that note it might be nice to show both the number of threads and cores and not only one of them. FreeBSD also has some other variables related to threads per core, but with the recent changes on processor topologies it seems worthless to me to use that since not every core is guaranteed to have the same number of threads...