### PR TITLE
[stable28] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -217,12 +217,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "bfdd4dcddff043a016cf0cf937018c70618b8a01"
+                "reference": "be3a853bcba7702887aab852fc3c8006787865d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/bfdd4dcddff043a016cf0cf937018c70618b8a01",
-                "reference": "bfdd4dcddff043a016cf0cf937018c70618b8a01",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/be3a853bcba7702887aab852fc3c8006787865d8",
+                "reference": "be3a853bcba7702887aab852fc3c8006787865d8",
                 "shasum": ""
             },
             "require": {
@@ -253,7 +253,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable28"
             },
-            "time": "2024-07-26T00:37:14+00:00"
+            "time": "2024-09-04T00:40:09+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency