### PR TITLE
feat(active users): add more active user statistics intervals and improve presentation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -259,3 +259,35 @@
 	align-items: center;
 	height: 24px;
 }
+
+.active-users-wrapper {
+	flex: 1;
+	display: flex;
+	gap: 0 1rem;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: center;
+}
+
+.active-users-box {
+	padding: 0.25rem 1rem;
+	flex: 1;
+	min-width: 150px;
+	border-left: 2px solid var(--color-border);
+}
+
+@media (width <= 1280px) {
+	.active-users-box {
+		padding: 1rem 0.5rem;
+		border: none;
+		text-align: center;
+	}
+}
+
+.active-users-box:first-child {
+	border: none;
+}
+
+.active-users-box .info {
+	font-size: 2rem;
+}

--- a/lib/SessionStatistics.php
+++ b/lib/SessionStatistics.php
@@ -25,6 +25,11 @@ class SessionStatistics {
 	private const OFFSET_5MIN = 300;
 	private const OFFSET_1HOUR = 3600;
 	private const OFFSET_1DAY = 86400;
+	private const OFFSET_7DAYS = 604800;
+	private const OFFSET_1MONTH = 2592000;
+	private const OFFSET_3MONTHS = 7776000;
+	private const OFFSET_6MONTHS = 15552000;
+	private const OFFSET_1YEAR = 31536000;
 
 	private IDBConnection $connection;
 	private ITimeFactory $timeFactory;
@@ -39,6 +44,11 @@ class SessionStatistics {
 			'last5minutes' => $this->getNumberOfActiveUsers(self::OFFSET_5MIN),
 			'last1hour' => $this->getNumberOfActiveUsers(self::OFFSET_1HOUR),
 			'last24hours' => $this->getNumberOfActiveUsers(self::OFFSET_1DAY),
+			'last7days' => $this->getNumberOfActiveUsers(self::OFFSET_7DAYS),
+			'last1month' => $this->getNumberOfActiveUsers(self::OFFSET_1MONTH),
+			'last3months' => $this->getNumberOfActiveUsers(self::OFFSET_3MONTHS),
+			'last6months' => $this->getNumberOfActiveUsers(self::OFFSET_6MONTHS),
+			'lastyear' => $this->getNumberOfActiveUsers(self::OFFSET_1YEAR),
 		];
 	}
 

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -227,27 +227,39 @@ $phpinfo = $_['phpinfo'];
 
 			<div class="col col-12">
 				<div class="row">
-					<div class="col col-4 col-l-6 col-m-12">
+					<div class="col">
 						<div class="infobox">
-							<div class="interface-wrapper">
-								<?php if ($_['storage']['num_users'] > 0) : ?>
-									<?php p($l->t('Total users:')); ?>
-									<span class="info"><?php p($_['storage']['num_users']); ?></span><br>
+							<div class="interface-wrapper active-users-wrapper">
+								<?php if ($_['activeUsers']['last1hour'] > 0) : ?>
+									<div class="active-users-box">
+										<?php p($l->t('Last hour')); ?><br>
+										<span class="info"><?php p($_['activeUsers']['last1hour']) ?></span><br>
+										<em><?php p($l->t('%s%% of all users', [round($_['activeUsers']['last1hour'] * 100 / $_['storage']['num_users'], 1)])) ?></em>
+									</div>
 								<?php endif; ?>
 
 								<?php if ($_['activeUsers']['last24hours'] > 0) : ?>
-									<?php p($l->t('24 hours:')); ?>
-									<span class="info"><?php p($_['activeUsers']['last24hours']) ?></span><br>
+									<div class="active-users-box">
+										<?php p($l->t('Last 24 Hours')); ?><br>
+										<span class="info"><?php p($_['activeUsers']['last24hours']) ?></span><br>
+										<em><?php p($l->t('%s%% of all users', [round($_['activeUsers']['last24hours'] * 100 / $_['storage']['num_users'], 1)])) ?></em>
+									</div>
 								<?php endif; ?>
 
-								<?php if ($_['activeUsers']['last1hour'] > 0) : ?>
-									<?php p($l->t('1 hour:')); ?>
-									<span class="info"><?php p($_['activeUsers']['last1hour']) ?></span><br>
+								<?php if ($_['activeUsers']['last7days'] > 0) : ?>
+									<div class="active-users-box">
+										<?php p($l->t('Last 7 Days')); ?><br>
+										<span class="info"><?php p($_['activeUsers']['last7days']) ?></span><br>
+										<em><?php p($l->t('%s%% of all users', [round($_['activeUsers']['last7days'] * 100 / $_['storage']['num_users'], 1)])) ?></em>
+									</div>
 								<?php endif; ?>
 
-								<?php if ($_['activeUsers']['last5minutes'] > 0) : ?>
-									<?php p($l->t('5 mins:')); ?>
-									<span class="info"><?php p($_['activeUsers']['last5minutes']) ?></span><br>
+								<?php if ($_['activeUsers']['last1month'] > 0) : ?>
+									<div class="active-users-box">
+										<?php p($l->t('Last 30 Days')); ?><br>
+										<span class="info"><?php p($_['activeUsers']['last1month']) ?></span><br>
+										<em><?php p($l->t('%s%% of all users', [round($_['activeUsers']['last1month'] * 100 / $_['storage']['num_users'], 1)])) ?></em>
+									</div>
 								<?php endif; ?>
 							</div>
 						</div>

--- a/tests/lib/SessionStatisticsTest.php
+++ b/tests/lib/SessionStatisticsTest.php
@@ -13,6 +13,8 @@ namespace OCA\ServerInfo\Tests;
 use OCA\ServerInfo\SessionStatistics;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IDBConnection;
+use OCP\Server;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 /**
@@ -22,72 +24,77 @@ use Test\TestCase;
  * @package OCA\ServerInfo\Tests
  */
 class SessionStatisticsTest extends TestCase {
-	/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject */
-	private $timeFactory;
+	private ITimeFactory&MockObject $timeFactory;
+	private IDBConnection $connection;
+	private SessionStatistics $instance;
+	private const TABLE = 'authtoken';
+	private const OFFSET_5MIN = 300;
+	private const OFFSET_1HOUR = 3600;
+	private const OFFSET_1DAY = 86400;
+	private const OFFSET_7DAYS = 604800;
+	private const OFFSET_1MONTH = 2592000;
+	private const OFFSET_3MONTHS = 7776000;
+	private const OFFSET_6MONTHS = 15552000;
+	private const OFFSET_1YEAR = 31536000;
+	private const CURRENT_TIME = 100000000;
 
-	/** @var IDBConnection */
-	private $connection;
-
-	/** @var SessionStatistics */
-	private $instance;
-
-	private $table = 'authtoken';
-
-	private $offset5Minutes = 300;
-
-	private $offset1Hour = 3600;
-
-	private $offset1Day = 86400;
-
-	private $currentTime = 100000;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->timeFactory = $this->getMockBuilder('OCP\AppFramework\Utility\ITimeFactory')
-			->disableOriginalConstructor()->getMock();
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 
-		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->connection = Server::get(IDBConnection::class);
 
 		$this->instance = new SessionStatistics($this->connection, $this->timeFactory);
 	}
 
-	private function addDummyValues() {
-		$this->addDummyValuesWithLastLogin($this->currentTime - $this->offset5Minutes + 1, 10);
-		$this->addDummyValuesWithLastLogin($this->currentTime - $this->offset1Hour + 1, 20);
-		$this->addDummyValuesWithLastLogin($this->currentTime - $this->offset1Day + 1, 30);
+	private function addDummyValues(): void {
+		$this->addDummyValuesWithLastLogin(self::CURRENT_TIME - self::OFFSET_5MIN + 1, 10);
+		$this->addDummyValuesWithLastLogin(self::CURRENT_TIME - self::OFFSET_1HOUR + 1, 20);
+		$this->addDummyValuesWithLastLogin(self::CURRENT_TIME - self::OFFSET_1DAY + 1, 30);
+		$this->addDummyValuesWithLastLogin(self::CURRENT_TIME - self::OFFSET_7DAYS + 1, 40);
+		$this->addDummyValuesWithLastLogin(self::CURRENT_TIME - self::OFFSET_1MONTH + 1, 50);
+		$this->addDummyValuesWithLastLogin(self::CURRENT_TIME - self::OFFSET_3MONTHS + 1, 60);
+		$this->addDummyValuesWithLastLogin(self::CURRENT_TIME - self::OFFSET_6MONTHS + 1, 70);
+		$this->addDummyValuesWithLastLogin(self::CURRENT_TIME - self::OFFSET_1YEAR + 1, 80);
 	}
 
-	private function addDummyValuesWithLastLogin($lastActivity, $numOfEntries) {
+	private function addDummyValuesWithLastLogin($lastActivity, $numOfEntries): void {
 		for ($i = 0; $i < $numOfEntries; $i++) {
 			$query = $this->connection->getQueryBuilder();
-			$query->insert($this->table)
+			$query->insert(self::TABLE)
 				->values(
 					[
 						'uid' => $query->createNamedParameter('user-' . ($numOfEntries + $i % 2)),
 						'login_name' => $query->createNamedParameter('user-' . ($numOfEntries + $i % 2)),
 						'password' => $query->createNamedParameter('password'),
 						'name' => $query->createNamedParameter('user agent'),
-						'token' => $query->createNamedParameter('token-' . ($i + $numOfEntries * 10)),
+						'token' => $query->createNamedParameter('token-' . $this->getUniqueID()),
 						'type' => $query->createNamedParameter(0),
 						'last_activity' => $query->createNamedParameter($lastActivity),
 						'last_check' => $query->createNamedParameter($lastActivity),
 					]
 				);
-			$query->execute();
+			$query->executeStatement();
 		}
 	}
 
 	public function testGetSessionStatistics() {
 		$this->addDummyValues();
 		$this->timeFactory->expects($this->any())->method('getTime')
-			->willReturn($this->currentTime);
+			->willReturn(self::CURRENT_TIME);
 
 		$result = $this->instance->getSessionStatistics();
 
-		$this->assertSame(3, count($result));
+		$this->assertSame(8, count($result));
 		$this->assertSame(2, $result['last5minutes']);
 		$this->assertSame(4, $result['last1hour']);
 		$this->assertSame(6, $result['last24hours']);
+		$this->assertSame(8, $result['last7days']);
+		$this->assertSame(10, $result['last1month']);
+		$this->assertSame(12, $result['last3months']);
+		$this->assertSame(14, $result['last6months']);
+		$this->assertSame(16, $result['lastyear']);
 	}
 }


### PR DESCRIPTION
Adds:
* last 7 days
* last 1 month
* last 3 months
* last 6 months
* last year

to the API endpoint.

This view will certainly get converted to Vue at some point (and with proper CSS variables), but it felt like a nice improvement (and to use the new metrics).

### Before
![Screenshot 2024-10-04 at 16-03-15 Système - Paramètres d'administration - Mon petit nuage](https://github.com/user-attachments/assets/57416485-93d3-44cc-861a-45f8796df864)

### After
#### Full width
![Screenshot 2024-10-04 at 16-00-56 System - Administration settings - Nextcloud](https://github.com/user-attachments/assets/17ade3ca-56a6-40d6-a4c5-d6ae8527acad)
#### Tablet
![Screenshot 2024-10-04 at 16-02-50 System - Administration settings - Nextcloud](https://github.com/user-attachments/assets/85274ead-d8ea-4ad4-88bd-58f57848d80f)
#### Large Mobile
![Screenshot 2024-10-04 at 16-01-45 System - Administration settings - Nextcloud](https://github.com/user-attachments/assets/8b57ef75-596b-48e5-a570-4d4d9e66b810)
#### Small Mobile
![Screenshot 2024-10-04 at 16-02-07 System - Administration settings - Nextcloud](https://github.com/user-attachments/assets/1a088ef5-613f-4857-9e55-b1389b0e4aa3)

