### PR TITLE
feat(storage): add size of appdata folder to statistics

### DIFF
--- a/lib/Jobs/UpdateStorageStats.php
+++ b/lib/Jobs/UpdateStorageStats.php
@@ -12,13 +12,13 @@ namespace OCA\ServerInfo\Jobs;
 use OCA\ServerInfo\StorageStatistics;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
-use OCP\IConfig;
+use OCP\IAppConfig;
 
 class UpdateStorageStats extends TimedJob {
 	private StorageStatistics $storageStatistics;
 
-	public function __construct(ITimeFactory $time, StorageStatistics $storageStatistics, IConfig $config) {
-		$this->setInterval((int)$config->getAppValue('serverinfo', 'job_interval_storage_stats', (string)(60 * 60 * 3)));
+	public function __construct(ITimeFactory $time, StorageStatistics $storageStatistics, IAppConfig $appConfig) {
+		$this->setInterval($appConfig->getValueInt('serverinfo', 'job_interval_storage_stats', 60 * 60 * 3));
 		parent::__construct($time);
 
 		$this->storageStatistics = $storageStatistics;

--- a/lib/StorageStatistics.php
+++ b/lib/StorageStatistics.php
@@ -12,21 +12,15 @@ namespace OCA\ServerInfo;
 
 use OCP\Files\IRootFolder;
 use OCP\IAppConfig;
-use OCP\IConfig;
 use OCP\IDBConnection;
 
 class StorageStatistics {
-	private IDBConnection $connection;
-	private IConfig $config;
 
 	public function __construct(
-		IDBConnection $connection,
-		IConfig $config,
+		private IDBConnection $connection,
 		private IRootFolder $rootFolder,
 		private IAppConfig $appConfig,
 	) {
-		$this->connection = $connection;
-		$this->config = $config;
 	}
 
 	public function getStorageStatistics(): array {
@@ -56,7 +50,7 @@ class StorageStatistics {
 	}
 
 	protected function getCountOf(string $table): int {
-		return (int)$this->config->getAppValue('serverinfo', 'cached_count_' . $table, '0');
+		return $this->appConfig->getValueInt('serverinfo', 'cached_count_' . $table);
 	}
 
 	public function updateStorageCounts(): void {
@@ -83,8 +77,8 @@ class StorageStatistics {
 
 		$this->updateAppDataStorageSize();
 
-		$this->config->setAppValue('serverinfo', 'cached_count_filecache', (string)$fileCount);
-		$this->config->setAppValue('serverinfo', 'cached_count_storages', (string)$storageCount);
+		$this->appConfig->setValueInt('serverinfo', 'cached_count_filecache', $fileCount);
+		$this->appConfig->setValueInt('serverinfo', 'cached_count_storages', $storageCount);
 	}
 
 	protected function countStorages(string $type): int {


### PR DESCRIPTION
App data is used for a lot of things and the preview folder especially can grow very much. This helps identifying where storage growth comes from.

Also refactor to use `IAppConfig` in related files.