### PR TITLE
fix(freebsd): fix cpu count for load graph

### DIFF
--- a/lib/OperatingSystems/FreeBSD.php
+++ b/lib/OperatingSystems/FreeBSD.php
@@ -79,8 +79,9 @@ class FreeBSD implements IOperatingSystem {
 		$numCpu = -1;
 
 		try {
-			$numCpu = intval($this->executeCommand('sysctl -n hw.ncpu')); //TODO: this should be tested if it actually works on FreeBSD
+			$numCpu = intval($this->executeCommand('/sbin/sysctl -n hw.ncpu'));
 		} catch (RuntimeException) {
+			return $numCpu;
 		}
 
 		return $numCpu;


### PR DESCRIPTION
**Nextcloud version:** 30.0.5

FreeBSD is showing "CPU info not available". The reason is the CPU count function is not calling the command correctly.

Fix Tested:
![image](https://github.com/user-attachments/assets/4b051e11-ff24-4c29-8c28-28837b1938a2)
