### PR TITLE
Fix serverinfo representation in nextcloud OCC command tool: add info…

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,6 +26,7 @@
 	</background-jobs>
 	<commands>
 		<command>OCA\ServerInfo\Commands\UpdateStorageStats</command>
+        <command>OCA\ServerInfo\Commands\GetInfo</command>
 	</commands>
     <settings>
         <admin>OCA\ServerInfo\Settings\AdminSettings</admin>

--- a/lib/Commands/GetInfo.php
+++ b/lib/Commands/GetInfo.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace OCA\ServerInfo\Commands;
+
+use OC\Core\Command\Base;
+use OCA\ServerInfo\Service\InfoService;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GetInfo extends Base {
+    private InfoService $serverInfoService;
+
+    public function __construct(InfoService $serverInfoService) {
+        parent::__construct();
+        $this->serverInfoService = $serverInfoService;
+    }
+
+    protected function configure(): void {
+        parent::configure();
+        $this->setName('serverinfo:info')
+             ->setDescription('Displays server information');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int {
+        $serverInfo = $this->serverInfoService->getServerInfo();
+        $this->writeArrayInOutputFormat($input, $output, $serverInfo);
+        
+        return 0;
+    }
+}

--- a/lib/Service/InfoService.php
+++ b/lib/Service/InfoService.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace OCA\ServerInfo\Service;
+
+use OCA\ServerInfo\DatabaseStatistics;
+use OCA\ServerInfo\PhpStatistics;
+use OCA\ServerInfo\SessionStatistics;
+use OCA\ServerInfo\ShareStatistics;
+use OCA\ServerInfo\StorageStatistics;
+use OCA\ServerInfo\SystemStatistics;
+
+class InfoService {
+    private SystemStatistics $systemStatistics;
+    private StorageStatistics $storageStatistics;
+    private PhpStatistics $phpStatistics;
+    private DatabaseStatistics $databaseStatistics;
+    private ShareStatistics $shareStatistics;
+    private SessionStatistics $sessionStatistics;
+
+    public function __construct(
+        SystemStatistics $systemStatistics,
+        StorageStatistics $storageStatistics,
+        PhpStatistics $phpStatistics,
+        DatabaseStatistics $databaseStatistics,
+        ShareStatistics $shareStatistics,
+        SessionStatistics $sessionStatistics
+    ) {
+        $this->systemStatistics = $systemStatistics;
+        $this->storageStatistics = $storageStatistics;
+        $this->phpStatistics = $phpStatistics;
+        $this->databaseStatistics = $databaseStatistics;
+        $this->shareStatistics = $shareStatistics;
+        $this->sessionStatistics = $sessionStatistics;
+    }
+
+    public function getServerInfo(bool $skipApps = true, bool $skipUpdate = true): array {
+        return [
+            'nextcloud' => [
+                'system' => $this->systemStatistics->getSystemStatistics($skipApps, $skipUpdate),
+                'storage' => $this->storageStatistics->getStorageStatistics(),
+                'shares' => $this->shareStatistics->getShareStatistics(),
+            ],
+            'server' => [
+                'webserver' => $this->getWebserver(),
+                'php' => $this->phpStatistics->getPhpStatistics(),
+                'database' => $this->databaseStatistics->getDatabaseStatistics(),
+            ],
+            'activeUsers' => $this->sessionStatistics->getSessionStatistics(),
+        ];
+    }
+
+    /**
+     * Get webserver information
+     */
+    private function getWebserver(): string {
+        if (isset($_SERVER['SERVER_SOFTWARE'])) {
+            return $_SERVER['SERVER_SOFTWARE'];
+        }
+        return 'unknown';
+    }
+}


### PR DESCRIPTION
This PR adds a new OCC command, as described in [issue #190](https://github.com/nextcloud/serverinfo/issues/190), to retrieve serverinfo data.
Fixes #190 

### Changes Made:
- Added occ command `php occ serverinfo:info`;
- Encapsulated some business logic of ApiController into a dedicated service layer