### PR TITLE
fix(i18n): Fix German translations

### DIFF
--- a/l10n/de.json
+++ b/l10n/de.json
@@ -1,7 +1,7 @@
 { "translations": {
     "CPU info not available" : "Informationen zur CPU nicht verfügbar",
     "CPU Usage:" : "CPU-Auslastung:",
-    "Load average: {percentage} % ({load}) last minute" : "Durchschnittliche Last: {percentage} % ({load}) in der letzen Minute",
+    "Load average: {percentage} % ({load}) last minute" : "Durchschnittliche Last: {percentage} % ({load}) in der letzten Minute",
     "{lastMinutePercentage} % ({lastMinute}) last Minute\n{last5MinutesPercentage} % ({last5Minutes}) last 5 Minutes\n{last15MinutesPercentage} % ({last15Minutes}) last 15 Minutes" : "{lastMinutePercentage} % ({lastMinute}) letzte Minute\n{last5MinutesPercentage} % ({last5Minutes}) letzte 5 Minuten\n{last15MinutesPercentage} % ({last15Minutes}) letzte 15 Minuten",
     "RAM Usage:" : "Speicherauslastung:",
     "SWAP Usage:" : "SWAP-Auslastung:",

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -3,7 +3,7 @@ OC.L10N.register(
     {
     "CPU info not available" : "Informationen zur CPU nicht verfügbar",
     "CPU Usage:" : "CPU-Auslastung:",
-    "Load average: {percentage} % ({load}) last minute" : "Durchschnittliche Last: {percentage} % ({load}) in der letzen Minute",
+    "Load average: {percentage} % ({load}) last minute" : "Durchschnittliche Last: {percentage} % ({load}) in der letzten Minute",
     "{lastMinutePercentage} % ({lastMinute}) last Minute\n{last5MinutesPercentage} % ({last5Minutes}) last 5 Minutes\n{last15MinutesPercentage} % ({last15Minutes}) last 15 Minutes" : "{lastMinutePercentage} % ({lastMinute}) letzte Minute\n{last5MinutesPercentage} % ({last5Minutes}) letzte 5 Minuten\n{last15MinutesPercentage} % ({last15Minutes}) letzte 15 Minuten",
     "RAM Usage:" : "Speicherauslastung:",
     "SWAP Usage:" : "SWAP-Auslastung:",


### PR DESCRIPTION
Corrected "letzen" to "letzten" in load average strings.