### PR TITLE
[stable33] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -104,12 +104,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "42bd0340ad5ac84615ba9ce83a488ce858a848bf"
+                "reference": "cfa8a058944df2afd3b0a8fbcaccf62dc418acf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/42bd0340ad5ac84615ba9ce83a488ce858a848bf",
-                "reference": "42bd0340ad5ac84615ba9ce83a488ce858a848bf",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/cfa8a058944df2afd3b0a8fbcaccf62dc418acf4",
+                "reference": "cfa8a058944df2afd3b0a8fbcaccf62dc418acf4",
                 "shasum": ""
             },
             "require": {
@@ -144,7 +144,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable33"
             },
-            "time": "2026-01-22T08:46:28+00:00"
+            "time": "2026-01-24T00:55:49+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency