### PR TITLE
[stable33] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -104,12 +104,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "cdb5232c76c7046ad44b6f8f123c8af160f6529f"
+                "reference": "542038d6304d6954c73e9496f7aec39d1bcecd00"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/cdb5232c76c7046ad44b6f8f123c8af160f6529f",
-                "reference": "cdb5232c76c7046ad44b6f8f123c8af160f6529f",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/542038d6304d6954c73e9496f7aec39d1bcecd00",
+                "reference": "542038d6304d6954c73e9496f7aec39d1bcecd00",
                 "shasum": ""
             },
             "require": {
@@ -144,7 +144,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable33"
             },
-            "time": "2026-04-08T01:20:30+00:00"
+            "time": "2026-04-28T01:53:24+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency