### PR TITLE
fix(disk): ignore efivarfs pseudo-mount

### DIFF
--- a/lib/OperatingSystems/Linux.php
+++ b/lib/OperatingSystems/Linux.php
@@ -204,7 +204,7 @@ class Linux implements IOperatingSystem {
 		}
 
 		foreach ($matches['Filesystem'] as $i => $filesystem) {
-			if (in_array($matches['Type'][$i], ['tmpfs', 'devtmpfs', 'squashfs', 'overlay'], false)) {
+			if (in_array($matches['Type'][$i], ['tmpfs', 'devtmpfs', 'squashfs', 'overlay', 'efivarfs'], false)) {
 				continue;
 			} elseif (in_array($matches['Mounted'][$i], ['/etc/hostname', '/etc/hosts'], false)) {
 				continue;


### PR DESCRIPTION
The efivarfs filesystem exposes EFI variables and reports as 100% full, which is correct for the kernel but misleading on the serverinfo dashboard. Treat it the same as tmpfs/devtmpfs/squashfs/ overlay and skip it in disk reporting.