### PR TITLE
feat(network): include DNS servers in network info

### DIFF
--- a/lib/OperatingSystems/FreeBSD.php
+++ b/lib/OperatingSystems/FreeBSD.php
@@ -101,6 +101,7 @@ class FreeBSD implements IOperatingSystem {
 		$result = [
 			'gateway' => '',
 			'hostname' => \gethostname(),
+			'dns' => '',
 		];
 
 		try {

--- a/lib/OperatingSystems/IOperatingSystem.php
+++ b/lib/OperatingSystems/IOperatingSystem.php
@@ -33,6 +33,7 @@ interface IOperatingSystem {
 	 * [
 	 *        'gateway' => string,
 	 *        'hostname' => string,
+	 *        'dns' => string,
 	 * ]
 	 */
 	public function getNetworkInfo(): array;

--- a/lib/OperatingSystems/Linux.php
+++ b/lib/OperatingSystems/Linux.php
@@ -126,10 +126,20 @@ class Linux implements IOperatingSystem {
 		$result = [
 			'gateway' => '',
 			'hostname' => \gethostname(),
+			'dns' => '',
 		];
 
 		if (function_exists('shell_exec')) {
 			$result['gateway'] = shell_exec('ip route | awk \'/default/ { print $3 }\'');
+		}
+
+		try {
+			$resolvConf = $this->readContent('/etc/resolv.conf');
+			if (preg_match_all('/^\s*nameserver\s+(\S+)/m', $resolvConf, $matches)) {
+				$result['dns'] = implode(', ', array_unique($matches[1]));
+			}
+		} catch (RuntimeException) {
+			// okay
 		}
 
 		return $result;

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -204,6 +204,10 @@ $phpinfo = $_['phpinfo'];
 				<span class="info"><?php p($_['networkinfo']['gateway']); ?></span>
 			</div>
 			<div class="col col-12">
+				<?php p($l->t('DNS:')); ?>
+				<span class="info"><?php p($_['networkinfo']['dns']); ?></span>
+			</div>
+			<div class="col col-12">
 				<div class="row">
 					<?php foreach ($interfaces as $interface): ?>
 
@@ -532,4 +536,3 @@ $phpinfo = $_['phpinfo'];
 	</div>
 
 </div>
-

--- a/tests/lib/DummyTest.php
+++ b/tests/lib/DummyTest.php
@@ -56,4 +56,12 @@ class DummyTest extends TestCase {
 	public function testGetNetworkInterfaces(): void {
 		$this->assertEquals([], $this->os->getNetworkInterfaces());
 	}
+
+	public function testGetNetworkInfo(): void {
+		$networkInfo = $this->os->getNetworkInfo();
+
+		$this->assertArrayHasKey('hostname', $networkInfo);
+		$this->assertSame('', $networkInfo['gateway']);
+		$this->assertSame('', $networkInfo['dns']);
+	}
 }

--- a/tests/lib/FreeBSDTest.php
+++ b/tests/lib/FreeBSDTest.php
@@ -134,6 +134,18 @@ class FreeBSDTest extends TestCase {
 		$this->assertEquals($expected, $actual);
 	}
 
+	public function testGetNetworkInfo(): void {
+		$this->os->method('executeCommand')
+			->with('netstat -rn')
+			->willReturn("Routing tables\n\ndefault            192.0.2.1        UGS\n");
+
+		$networkInfo = $this->os->getNetworkInfo();
+
+		$this->assertSame('192.0.2.1', $networkInfo['gateway']);
+		$this->assertSame('', $networkInfo['dns']);
+		$this->assertArrayHasKey('hostname', $networkInfo);
+	}
+
 	public function testGetNetworkInterfacesError(): void {
 		$this->os->method('getNetInterfaces')
 			->willThrowException(new RuntimeException('Unable to get network interfaces'));

--- a/tests/lib/LinuxTest.php
+++ b/tests/lib/LinuxTest.php
@@ -256,6 +256,30 @@ class LinuxTest extends TestCase {
 		$this->assertTrue($this->os->supported());
 	}
 
+	public function testGetNetworkInfo(): void {
+		$this->os->method('readContent')
+			->with('/etc/resolv.conf')
+			->willReturn("# comment\nnameserver 127.0.0.53\nnameserver 1.1.1.1\n; ignored\nnameserver 127.0.0.53");
+
+		$networkInfo = $this->os->getNetworkInfo();
+
+		$this->assertSame('127.0.0.53, 1.1.1.1', $networkInfo['dns']);
+		$this->assertArrayHasKey('hostname', $networkInfo);
+		$this->assertArrayHasKey('gateway', $networkInfo);
+	}
+
+	public function testGetNetworkInfoWithoutResolvConf(): void {
+		$this->os->method('readContent')
+			->with('/etc/resolv.conf')
+			->willThrowException(new RuntimeException('Unable to read: "/etc/resolv.conf"'));
+
+		$networkInfo = $this->os->getNetworkInfo();
+
+		$this->assertSame('', $networkInfo['dns']);
+		$this->assertArrayHasKey('hostname', $networkInfo);
+		$this->assertArrayHasKey('gateway', $networkInfo);
+	}
+
 	public function testGetNetworkInterfaces(): void {
 		$this->os->method('getNetInterfaces')
 			->willReturn(json_decode(file_get_contents(__DIR__ . '/../data/linux_net_get_interfaces.json'), true, 512, JSON_THROW_ON_ERROR));


### PR DESCRIPTION
Reads nameserver entries from /etc/resolv.conf (no shell, no sudo) and exposes them as a comma-separated string in getNetworkInfo()['dns']. Comments and empty lines are ignored; duplicate servers are deduped.