### PR TITLE
feat(services): add cron and background-job services

### DIFF
--- a/lib/CronInfo.php
+++ b/lib/CronInfo.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\ServerInfo;
+
+use OCP\IAppConfig;
+use OCP\IConfig;
+
+class CronInfo {
+	public function __construct(
+		private IConfig $config,
+		private IAppConfig $appConfig,
+	) {
+	}
+
+	/**
+	 * @return array{
+	 *     mode: string,
+	 *     lastRun: int,
+	 *     secondsSince: int,
+	 *     status: string
+	 * }
+	 */
+	public function getCronInfo(): array {
+		$mode = $this->config->getAppValue('core', 'backgroundjobs_mode', 'ajax');
+		$lastRun = $this->appConfig->getValueInt('core', 'lastcron', 0);
+		$secondsSince = $lastRun > 0 ? max(0, time() - $lastRun) : -1;
+
+		return [
+			'mode' => $mode,
+			'lastRun' => $lastRun,
+			'secondsSince' => $secondsSince,
+			'status' => $this->statusFor($mode, $secondsSince),
+		];
+	}
+
+	private function statusFor(string $mode, int $secondsSince): string {
+		if ($secondsSince < 0) {
+			return 'critical';
+		}
+		// Cron job runs every 5 minutes; allow a generous grace period.
+		if ($mode === 'cron') {
+			if ($secondsSince > 3600) {
+				return 'critical';
+			}
+			if ($secondsSince > 900) {
+				return 'warning';
+			}
+			return 'ok';
+		}
+		// Webcron / ajax modes: looser thresholds.
+		if ($secondsSince > 7200) {
+			return 'critical';
+		}
+		if ($secondsSince > 3600) {
+			return 'warning';
+		}
+		return 'ok';
+	}
+}

--- a/lib/JobQueueInfo.php
+++ b/lib/JobQueueInfo.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\ServerInfo;
+
+use OCP\IDBConnection;
+
+class JobQueueInfo {
+	private const STUCK_THRESHOLD_SECONDS = 12 * 3600;
+
+	public function __construct(
+		private IDBConnection $db,
+	) {
+	}
+
+	/**
+	 * @return array{
+	 *     total: int,
+	 *     reserved: int,
+	 *     stuck: int,
+	 *     oldestLastRun: int,
+	 *     topClasses: list<array{class: string, count: int}>
+	 * }
+	 */
+	public function getJobQueueInfo(): array {
+		return [
+			'total' => $this->countTotal(),
+			'reserved' => $this->countReserved(),
+			'stuck' => $this->countStuck(),
+			'oldestLastRun' => $this->oldestLastRun(),
+			'topClasses' => $this->topClasses(5),
+		];
+	}
+
+	private function countTotal(): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($qb->func()->count('id'))
+			->from('jobs');
+		$result = $qb->executeQuery();
+		$count = (int)$result->fetchOne();
+		$result->closeCursor();
+		return $count;
+	}
+
+	private function countReserved(): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($qb->func()->count('id'))
+			->from('jobs')
+			->where($qb->expr()->gt('reserved_at', $qb->createNamedParameter(0)));
+		$result = $qb->executeQuery();
+		$count = (int)$result->fetchOne();
+		$result->closeCursor();
+		return $count;
+	}
+
+	private function countStuck(): int {
+		$threshold = time() - self::STUCK_THRESHOLD_SECONDS;
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($qb->func()->count('id'))
+			->from('jobs')
+			->where($qb->expr()->gt('reserved_at', $qb->createNamedParameter(0)))
+			->andWhere($qb->expr()->lt('reserved_at', $qb->createNamedParameter($threshold)));
+		$result = $qb->executeQuery();
+		$count = (int)$result->fetchOne();
+		$result->closeCursor();
+		return $count;
+	}
+
+	private function oldestLastRun(): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($qb->func()->min('last_run'))
+			->from('jobs')
+			->where($qb->expr()->gt('last_run', $qb->createNamedParameter(0)));
+		$result = $qb->executeQuery();
+		$min = $result->fetchOne();
+		$result->closeCursor();
+		return $min === false || $min === null ? 0 : (int)$min;
+	}
+
+	/**
+	 * @return list<array{class: string, count: int}>
+	 */
+	private function topClasses(int $limit): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('class')
+			->selectAlias($qb->func()->count('id'), 'count')
+			->from('jobs')
+			->groupBy('class')
+			->orderBy('count', 'DESC')
+			->setMaxResults($limit);
+		$result = $qb->executeQuery();
+		$out = [];
+		while (($row = $result->fetch()) !== false) {
+			$out[] = [
+				'class' => (string)($row['class'] ?? ''),
+				'count' => (int)($row['count'] ?? 0),
+			];
+		}
+		$result->closeCursor();
+		return $out;
+	}
+}

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -10,12 +10,15 @@ declare(strict_types=1);
 
 namespace OCA\ServerInfo\Settings;
 
+use OCA\ServerInfo\CronInfo;
 use OCA\ServerInfo\DatabaseStatistics;
 use OCA\ServerInfo\FpmStatistics;
+use OCA\ServerInfo\JobQueueInfo;
 use OCA\ServerInfo\Os;
 use OCA\ServerInfo\PhpStatistics;
 use OCA\ServerInfo\SessionStatistics;
 use OCA\ServerInfo\ShareStatistics;
+use OCA\ServerInfo\SlowestJobs;
 use OCA\ServerInfo\StorageStatistics;
 use OCA\ServerInfo\SystemStatistics;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -36,6 +39,9 @@ class AdminSettings implements ISettings {
 		private ShareStatistics $shareStatistics,
 		private SessionStatistics $sessionStatistics,
 		private SystemStatistics $systemStatistics,
+		private CronInfo $cronInfo,
+		private JobQueueInfo $jobQueueInfo,
+		private SlowestJobs $slowestJobs,
 		private IConfig $config,
 	) {
 	}
@@ -60,6 +66,9 @@ class AdminSettings implements ISettings {
 			'activeUsers' => $this->sessionStatistics->getSessionStatistics(),
 			'system' => $this->systemStatistics->getSystemStatistics(true, true),
 			'thermalzones' => $this->os->getThermalZones(),
+			'cron' => $this->cronInfo->getCronInfo(),
+			'jobQueue' => $this->jobQueueInfo->getJobQueueInfo(),
+			'slowestJobs' => $this->slowestJobs->getSlowestJobs(),
 			'phpinfo' => $this->config->getAppValue('serverinfo', 'phpinfo', 'no') === 'yes',
 			'phpinfoUrl' => $this->urlGenerator->linkToRoute('serverinfo.page.phpinfo')
 		];

--- a/lib/SlowestJobs.php
+++ b/lib/SlowestJobs.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\ServerInfo;
+
+use OCP\IDBConnection;
+use Psr\Log\LoggerInterface;
+
+class SlowestJobs {
+	public function __construct(
+		private IDBConnection $db,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Returns the job classes with the highest average execution time
+	 * (last_run - last_checked when reservations are released). Pulls
+	 * the columns directly because there is no public API.
+	 *
+	 * @return list<array{class: string, count: int, avgSeconds: int, maxSeconds: int}>
+	 */
+	public function getSlowestJobs(int $limit = 5): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('class')
+			->selectAlias($qb->func()->count('id'), 'count')
+			->selectAlias($qb->createFunction('AVG(' . $qb->getColumnName('execution_duration') . ')'), 'avg_dur')
+			->selectAlias($qb->createFunction('MAX(' . $qb->getColumnName('execution_duration') . ')'), 'max_dur')
+			->from('jobs')
+			->where($qb->expr()->gt('execution_duration', $qb->createNamedParameter(0)))
+			->groupBy('class')
+			->orderBy('avg_dur', 'DESC')
+			->setMaxResults($limit);
+		try {
+			$result = $qb->executeQuery();
+		} catch (\Throwable $e) {
+			$this->logger->warning('Failed to query slowest jobs', ['exception' => $e]);
+			return [];
+		}
+		$out = [];
+		while (($row = $result->fetch()) !== false) {
+			$out[] = [
+				'class' => (string)($row['class'] ?? ''),
+				'count' => (int)($row['count'] ?? 0),
+				'avgSeconds' => (int)round((float)($row['avg_dur'] ?? 0)),
+				'maxSeconds' => (int)($row['max_dur'] ?? 0),
+			];
+		}
+		$result->closeCursor();
+		return $out;
+	}
+}

--- a/tests/lib/CronInfoTest.php
+++ b/tests/lib/CronInfoTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\ServerInfo\Tests;
+
+use OCA\ServerInfo\CronInfo;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class CronInfoTest extends \Test\TestCase {
+	private IConfig&MockObject $config;
+	private IAppConfig&MockObject $appConfig;
+	private CronInfo $instance;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->instance = new CronInfo($this->config, $this->appConfig);
+	}
+
+	public function testNeverRanIsCritical(): void {
+		$this->config->method('getAppValue')->willReturn('cron');
+		$this->appConfig->method('getValueInt')->willReturn(0);
+
+		$info = $this->instance->getCronInfo();
+
+		$this->assertSame('cron', $info['mode']);
+		$this->assertSame(0, $info['lastRun']);
+		$this->assertSame(-1, $info['secondsSince']);
+		$this->assertSame('critical', $info['status']);
+	}
+
+	public function testCronModeRecentRunIsOk(): void {
+		$this->config->method('getAppValue')->willReturn('cron');
+		$this->appConfig->method('getValueInt')->willReturn(time() - 60);
+
+		$info = $this->instance->getCronInfo();
+
+		$this->assertSame('ok', $info['status']);
+	}
+
+	public function testCronModeOver15MinIsWarning(): void {
+		$this->config->method('getAppValue')->willReturn('cron');
+		$this->appConfig->method('getValueInt')->willReturn(time() - 1000);
+
+		$info = $this->instance->getCronInfo();
+
+		$this->assertSame('warning', $info['status']);
+	}
+
+	public function testCronModeOver1HourIsCritical(): void {
+		$this->config->method('getAppValue')->willReturn('cron');
+		$this->appConfig->method('getValueInt')->willReturn(time() - 4000);
+
+		$info = $this->instance->getCronInfo();
+
+		$this->assertSame('critical', $info['status']);
+	}
+
+	public function testWebcronModeOver2HoursIsCritical(): void {
+		$this->config->method('getAppValue')->willReturn('webcron');
+		$this->appConfig->method('getValueInt')->willReturn(time() - 8000);
+
+		$info = $this->instance->getCronInfo();
+
+		$this->assertSame('webcron', $info['mode']);
+		$this->assertSame('critical', $info['status']);
+	}
+
+	public function testWebcronModeOver1HourIsWarning(): void {
+		$this->config->method('getAppValue')->willReturn('webcron');
+		$this->appConfig->method('getValueInt')->willReturn(time() - 5000);
+
+		$info = $this->instance->getCronInfo();
+
+		$this->assertSame('warning', $info['status']);
+	}
+
+	public function testWebcronModeRecentRunIsOk(): void {
+		$this->config->method('getAppValue')->willReturn('webcron');
+		$this->appConfig->method('getValueInt')->willReturn(time() - 60);
+
+		$info = $this->instance->getCronInfo();
+
+		$this->assertSame('ok', $info['status']);
+	}
+}

--- a/tests/lib/JobQueueInfoTest.php
+++ b/tests/lib/JobQueueInfoTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\ServerInfo\Tests;
+
+use OCA\ServerInfo\JobQueueInfo;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IFunctionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\QueryBuilder\IQueryFunction;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class JobQueueInfoTest extends \Test\TestCase {
+	private IDBConnection&MockObject $db;
+	private JobQueueInfo $instance;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->db = $this->createMock(IDBConnection::class);
+		$this->instance = new JobQueueInfo($this->db);
+	}
+
+	private function makeQb(mixed $fetchOneReturn = null, array $fetchRows = []): IQueryBuilder&MockObject {
+		$expr = $this->createMock(IExpressionBuilder::class);
+		$expr->method('gt')->willReturn('1=1');
+		$expr->method('lt')->willReturn('1=1');
+
+		$queryFunction = $this->createMock(IQueryFunction::class);
+		$func = $this->createMock(IFunctionBuilder::class);
+		$func->method('count')->willReturn($queryFunction);
+		$func->method('min')->willReturn($queryFunction);
+
+		$result = $this->createMock(IResult::class);
+		if ($fetchOneReturn !== null) {
+			$result->method('fetchOne')->willReturn($fetchOneReturn);
+		}
+		if (!empty($fetchRows)) {
+			$result->method('fetch')->willReturnOnConsecutiveCalls(...$fetchRows);
+		}
+
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('select')->willReturnSelf();
+		$qb->method('selectAlias')->willReturnSelf();
+		$qb->method('from')->willReturnSelf();
+		$qb->method('where')->willReturnSelf();
+		$qb->method('andWhere')->willReturnSelf();
+		$qb->method('groupBy')->willReturnSelf();
+		$qb->method('orderBy')->willReturnSelf();
+		$qb->method('setMaxResults')->willReturnSelf();
+		$qb->method('expr')->willReturn($expr);
+		$qb->method('func')->willReturn($func);
+		$qb->method('createNamedParameter')->willReturnArgument(0);
+		$qb->method('executeQuery')->willReturn($result);
+
+		return $qb;
+	}
+
+	public function testGetJobQueueInfo(): void {
+		$this->db->method('getQueryBuilder')->willReturnOnConsecutiveCalls(
+			$this->makeQb(fetchOneReturn: '42'),   // countTotal
+			$this->makeQb(fetchOneReturn: '3'),    // countReserved
+			$this->makeQb(fetchOneReturn: '1'),    // countStuck
+			$this->makeQb(fetchOneReturn: '1700000000'), // oldestLastRun
+			$this->makeQb(fetchRows: [            // topClasses
+				['class' => 'OC\Files\BackgroundJob\ScanFiles', 'count' => '30'],
+				false,
+			]),
+		);
+
+		$info = $this->instance->getJobQueueInfo();
+
+		$this->assertSame(42, $info['total']);
+		$this->assertSame(3, $info['reserved']);
+		$this->assertSame(1, $info['stuck']);
+		$this->assertSame(1700000000, $info['oldestLastRun']);
+		$this->assertCount(1, $info['topClasses']);
+		$this->assertSame('OC\Files\BackgroundJob\ScanFiles', $info['topClasses'][0]['class']);
+		$this->assertSame(30, $info['topClasses'][0]['count']);
+	}
+
+	public function testOldestLastRunReturnsZeroWhenNoJobs(): void {
+		$this->db->method('getQueryBuilder')->willReturnOnConsecutiveCalls(
+			$this->makeQb(fetchOneReturn: '0'),
+			$this->makeQb(fetchOneReturn: '0'),
+			$this->makeQb(fetchOneReturn: '0'),
+			$this->makeQb(fetchOneReturn: false),
+			$this->makeQb(fetchRows: [false]),
+		);
+
+		$info = $this->instance->getJobQueueInfo();
+
+		$this->assertSame(0, $info['oldestLastRun']);
+		$this->assertSame([], $info['topClasses']);
+	}
+}

--- a/tests/lib/SlowestJobsTest.php
+++ b/tests/lib/SlowestJobsTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\ServerInfo\Tests;
+
+use OCA\ServerInfo\SlowestJobs;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+
+class SlowestJobsTest extends \Test\TestCase {
+	private IDBConnection&MockObject $db;
+	private LoggerInterface&MockObject $logger;
+	private SlowestJobs $instance;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->db = $this->createMock(IDBConnection::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->instance = new SlowestJobs($this->db, $this->logger);
+	}
+
+	public function testGetSlowestJobsReturnsResults(): void {
+		$result = $this->createMock(IResult::class);
+		$result->method('fetch')->willReturnOnConsecutiveCalls(
+			['class' => 'OC\Files\BackgroundJob\ScanFiles', 'count' => '12', 'avg_dur' => '4.5', 'max_dur' => '9'],
+			false,
+		);
+		$result->expects($this->once())->method('closeCursor');
+
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('select')->willReturnSelf();
+		$qb->method('selectAlias')->willReturnSelf();
+		$qb->method('from')->willReturnSelf();
+		$qb->method('where')->willReturnSelf();
+		$qb->method('groupBy')->willReturnSelf();
+		$qb->method('orderBy')->willReturnSelf();
+		$qb->method('setMaxResults')->willReturnSelf();
+		$qb->method('func')->willReturn($this->createMock(\OCP\DB\QueryBuilder\IFunctionBuilder::class));
+		$qb->method('expr')->willReturn($this->createMock(\OCP\DB\QueryBuilder\IExpressionBuilder::class));
+		$qb->method('createNamedParameter')->willReturnArgument(0);
+		$qb->method('getColumnName')->willReturnArgument(0);
+		$qb->method('createFunction')->willReturnArgument(0);
+		$qb->method('executeQuery')->willReturn($result);
+
+		$this->db->method('getQueryBuilder')->willReturn($qb);
+
+		$jobs = $this->instance->getSlowestJobs();
+
+		$this->assertCount(1, $jobs);
+		$this->assertSame('OC\Files\BackgroundJob\ScanFiles', $jobs[0]['class']);
+		$this->assertSame(12, $jobs[0]['count']);
+		$this->assertSame(5, $jobs[0]['avgSeconds']);
+		$this->assertSame(9, $jobs[0]['maxSeconds']);
+	}
+
+	public function testGetSlowestJobsLogsAndReturnsEmptyOnFailure(): void {
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('select')->willReturnSelf();
+		$qb->method('selectAlias')->willReturnSelf();
+		$qb->method('from')->willReturnSelf();
+		$qb->method('where')->willReturnSelf();
+		$qb->method('groupBy')->willReturnSelf();
+		$qb->method('orderBy')->willReturnSelf();
+		$qb->method('setMaxResults')->willReturnSelf();
+		$qb->method('func')->willReturn($this->createMock(\OCP\DB\QueryBuilder\IFunctionBuilder::class));
+		$qb->method('expr')->willReturn($this->createMock(\OCP\DB\QueryBuilder\IExpressionBuilder::class));
+		$qb->method('createNamedParameter')->willReturnArgument(0);
+		$qb->method('getColumnName')->willReturnArgument(0);
+		$qb->method('createFunction')->willReturnArgument(0);
+		$qb->method('executeQuery')->willThrowException(new \RuntimeException('DB error'));
+
+		$this->db->method('getQueryBuilder')->willReturn($qb);
+
+		$this->logger->expects($this->once())
+			->method('warning')
+			->with('Failed to query slowest jobs', $this->arrayHasKey('exception'));
+
+		$jobs = $this->instance->getSlowestJobs();
+
+		$this->assertSame([], $jobs);
+	}
+}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -10,6 +10,11 @@
       <code><![CDATA[PageController]]></code>
     </UnusedClass>
   </file>
+  <file src="lib/CronInfo.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="lib/DatabaseStatistics.php">
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>
@@ -26,6 +31,11 @@
     <PossiblyInvalidArrayAssignment>
       <code><![CDATA[$status['start-time']]]></code>
     </PossiblyInvalidArrayAssignment>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="lib/JobQueueInfo.php">
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
@@ -84,6 +94,11 @@
     <UnusedClass>
       <code><![CDATA[AdminSettings]]></code>
     </UnusedClass>
+  </file>
+  <file src="lib/SlowestJobs.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[__construct]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="lib/ShareStatistics.php">
     <PossiblyUnusedMethod>


### PR DESCRIPTION
Adds three read-only service classes used by the upcoming admin dashboard cards. None are wired into existing controllers yet, so this change is a pure addition with no behavior change.

* CronInfo      - cron mode (cron / webcron / ajax), last-run
                  timestamp, and a status threshold
* JobQueueInfo  - total / reserved / stuck job counts and the top
                  job classes by queue size
* SlowestJobs   - average and max execution time per job class