### PR TITLE
fix(disk): stop dropping filesystems whose mount point has unusual ch…

### DIFF
--- a/lib/OperatingSystems/FreeBSD.php
+++ b/lib/OperatingSystems/FreeBSD.php
@@ -187,7 +187,11 @@ class FreeBSD implements IOperatingSystem {
 		}
 
 		$matches = [];
-		$pattern = '/^(?<Filesystem>[\S]+)\s*(?<Type>[\S]+)\s*(?<Blocks>\d+)\s*(?<Used>\d+)\s*(?<Available>\d+)\s*(?<Capacity>\d+%)\s*(?<Mounted>[\w\/-]+)$/m';
+		// `df -P` prints one record per line with the mount point last, so the mount
+		// point is everything after the capacity column. Used and Capacity are loose
+		// because nothing reads them and `df` prints "-" for filesystems without
+		// usage numbers.
+		$pattern = '/^(?<Filesystem>\S+)[ \t]+(?<Type>\S+)[ \t]+(?<Blocks>\d+)[ \t]+(?<Used>\S+)[ \t]+(?<Available>\d+)[ \t]+(?<Capacity>\S+)[ \t]+(?<Mounted>\S.*?)[ \t\r]*$/m';
 
 		$result = preg_match_all($pattern, $disks, $matches);
 		if ($result === 0 || $result === false) {

--- a/lib/OperatingSystems/Linux.php
+++ b/lib/OperatingSystems/Linux.php
@@ -206,7 +206,11 @@ class Linux implements IOperatingSystem {
 		}
 
 		$matches = [];
-		$pattern = '/^(?<Filesystem>[\S]+)\s*(?<Type>[\S]+)\s*(?<Blocks>\d+)\s*(?<Used>\d+)\s*(?<Available>\d+)\s*(?<Capacity>\d+%)\s*(?<Mounted>[\w\/\-\.]+)$/m';
+		// `df -P` prints one record per line with the mount point last, so the mount
+		// point is everything after the capacity column. Used and Capacity are loose
+		// because nothing reads them and `df` prints "-" for filesystems without
+		// usage numbers.
+		$pattern = '/^(?<Filesystem>\S+)[ \t]+(?<Type>\S+)[ \t]+(?<Blocks>\d+)[ \t]+(?<Used>\S+)[ \t]+(?<Available>\d+)[ \t]+(?<Capacity>\S+)[ \t]+(?<Mounted>\S.*?)[ \t\r]*$/m';
 
 		$result = preg_match_all($pattern, $disks, $matches);
 		if ($result === 0 || $result === false) {

--- a/tests/data/freebsd_df_tp_mount_points
+++ b/tests/data/freebsd_df_tp_mount_points
@@ -1,0 +1,5 @@
+Filesystem       Type 1024-blocks      Used Available Capacity Mounted on
+/dev/gpt/rootfs  ufs     56422560   6205468  47321220      12% /
+zroot/data       zfs     10000000   2000000   8000000      20% /mnt/My Backup
+zroot/media      zfs     20000000   4000000  16000000      20% /mnt/media.old
+storage:/vol     nfs     40000000         -  32000000        - /mnt/nfs

--- a/tests/data/linux_df_tp_mount_points
+++ b/tests/data/linux_df_tp_mount_points
@@ -1,0 +1,6 @@
+Filesystem     Type   1024-blocks      Used Available Capacity Mounted on
+/dev/sda1      ext4      56422560   6205468  47321220      12% /
+/dev/sdb1      ext4      10000000   2000000   8000000      20% /mnt/My Backup
+/dev/sdc1      ext4      20000000   4000000  16000000      20% /mnt/Fotos-Übung
+/dev/sdd1      btrfs     30000000   6000000  24000000      20% /mnt/data (old)
+storage:/vol   nfs4      40000000         -  32000000        - /mnt/nfs

--- a/tests/lib/FreeBSDTest.php
+++ b/tests/lib/FreeBSDTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\ServerInfo\Tests;
 
 use OCA\ServerInfo\OperatingSystems\FreeBSD;
+use OCA\ServerInfo\Resources\Disk;
 use OCA\ServerInfo\Resources\Memory;
 use OCA\ServerInfo\Resources\NetInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -132,6 +133,49 @@ class FreeBSDTest extends TestCase {
 		$actual = $this->os->getNetworkInterfaces();
 
 		$this->assertEquals($expected, $actual);
+	}
+
+	public function testGetDiskInfoUnusualMountPoints(): void {
+		$this->os->method('executeCommand')
+			->with('df -TPk')
+			->willReturn(file_get_contents(__DIR__ . '/../data/freebsd_df_tp_mount_points'));
+
+		// getDiskInfo() had no coverage here at all, and this pattern was even
+		// narrower than the Linux one: it allowed no dots, so a mount point like
+		// /mnt/media.old removed that filesystem from the report entirely.
+		$disk1 = new Disk();
+		$disk1->setDevice('/dev/gpt/rootfs');
+		$disk1->setFs('ufs');
+		$disk1->setUsed(8889);
+		$disk1->setAvailable(46212);
+		$disk1->setPercent('16.13%');
+		$disk1->setMount('/');
+
+		$disk2 = new Disk();
+		$disk2->setDevice('zroot/data');
+		$disk2->setFs('zfs');
+		$disk2->setUsed(1954);
+		$disk2->setAvailable(7812);
+		$disk2->setPercent('20%');
+		$disk2->setMount('/mnt/My Backup');
+
+		$disk3 = new Disk();
+		$disk3->setDevice('zroot/media');
+		$disk3->setFs('zfs');
+		$disk3->setUsed(3907);
+		$disk3->setAvailable(15625);
+		$disk3->setPercent('20%');
+		$disk3->setMount('/mnt/media.old');
+
+		$disk4 = new Disk();
+		$disk4->setDevice('storage:/vol');
+		$disk4->setFs('nfs');
+		$disk4->setUsed(7813);
+		$disk4->setAvailable(31250);
+		$disk4->setPercent('20%');
+		$disk4->setMount('/mnt/nfs');
+
+		$this->assertEquals([$disk1, $disk2, $disk3, $disk4], $this->os->getDiskInfo());
 	}
 
 	public function testGetNetworkInfo(): void {

--- a/tests/lib/LinuxTest.php
+++ b/tests/lib/LinuxTest.php
@@ -251,6 +251,78 @@ class LinuxTest extends TestCase {
 		$this->assertEquals([], $this->os->getDiskInfo());
 	}
 
+	public function testGetDiskInfoSkipsMalformedLine(): void {
+		$this->os->method('executeCommand')
+			->with('df -TPk')
+			->willReturn("a b 1 c 2\n/dev/sda1 ext4 10000000 2000000 8000000 20% /mnt/data\n");
+
+		$disk = new Disk();
+		$disk->setDevice('/dev/sda1');
+		$disk->setFs('ext4');
+		$disk->setUsed(1954);
+		$disk->setAvailable(7812);
+		$disk->setPercent('20%');
+		$disk->setMount('/mnt/data');
+
+		$this->assertEquals([$disk], $this->os->getDiskInfo());
+	}
+
+	public function testGetDiskInfoUnusualMountPoints(): void {
+		$this->os->method('executeCommand')
+			->with('df -TPk')
+			->willReturn(file_get_contents(__DIR__ . '/../data/linux_df_tp_mount_points'));
+
+		// Only the first of these five used to be reported. The other four were
+		// dropped by the mount point pattern, which silently removed the whole
+		// filesystem from the monitoring page rather than reporting it partially.
+		$disk1 = new Disk();
+		$disk1->setDevice('/dev/sda1');
+		$disk1->setFs('ext4');
+		$disk1->setUsed(8889);
+		$disk1->setAvailable(46212);
+		$disk1->setPercent('16.13%');
+		$disk1->setMount('/');
+
+		// A space in the mount point
+		$disk2 = new Disk();
+		$disk2->setDevice('/dev/sdb1');
+		$disk2->setFs('ext4');
+		$disk2->setUsed(1954);
+		$disk2->setAvailable(7812);
+		$disk2->setPercent('20%');
+		$disk2->setMount('/mnt/My Backup');
+
+		// Non-ASCII, which \w does not cover without the unicode flag
+		$disk3 = new Disk();
+		$disk3->setDevice('/dev/sdc1');
+		$disk3->setFs('ext4');
+		$disk3->setUsed(3907);
+		$disk3->setAvailable(15625);
+		$disk3->setPercent('20%');
+		$disk3->setMount('/mnt/Fotos-Übung');
+
+		// Parentheses
+		$disk4 = new Disk();
+		$disk4->setDevice('/dev/sdd1');
+		$disk4->setFs('btrfs');
+		$disk4->setUsed(5860);
+		$disk4->setAvailable(23437);
+		$disk4->setPercent('20%');
+		$disk4->setMount('/mnt/data (old)');
+
+		// `df` prints "-" for used and capacity when a filesystem does not report
+		// them; both are unread here, so the row is still usable
+		$disk5 = new Disk();
+		$disk5->setDevice('storage:/vol');
+		$disk5->setFs('nfs4');
+		$disk5->setUsed(7813);
+		$disk5->setAvailable(31250);
+		$disk5->setPercent('20%');
+		$disk5->setMount('/mnt/nfs');
+
+		$this->assertEquals([$disk1, $disk2, $disk3, $disk4, $disk5], $this->os->getDiskInfo());
+	}
+
 	public function testSupported(): void {
 		$this->assertTrue($this->os->supported());
 	}


### PR DESCRIPTION
…aracters

getDiskInfo() matched the mount point against a character class — [\w\/\-\.] on Linux, [\w\/-] on FreeBSD, which did not even allow a dot. A mount point containing anything outside that set failed the whole line, and because the pattern is applied per line with preg_match_all, failing the line removed the entire filesystem from the report. No warning and no log entry: it simply was not there.

A space is enough. So is a non-ASCII character, since \w does not cover one without the unicode flag, and so are brackets. On the new fixture the old Linux pattern matches 1 of 5 filesystems.

`df -P` exists precisely so that output is machine readable: one record per line, no wrapping, and the mount point last. The mount point is therefore everything after the capacity column, which is what the pattern now says instead of trying to predict which characters can appear in a path.

Two smaller changes in the same expression:

Separators are now \s+ rather than \s*. The columns are whitespace separated, so allowing zero whitespace only worked by backtracking.

Used and Capacity are now matched as \S+ rather than requiring digits and a literal percent sign. Nothing reads either of them — used is recomputed from Blocks minus Available — and `df` prints "-" in them for filesystems that do not report usage, which was another way for a row to disappear. Blocks and Available still require digits, because those are the values actually used.

Verified by running the new tests against the unfixed collectors: Linux reports 1 filesystem where 5 are expected, FreeBSD 1 where 4 are expected, and both pass after the change. The existing 7-disk expectation is untouched, so the new pattern is a superset of the old one on output that already parsed. FreeBSD's getDiskInfo() had no coverage at all and gains its first.



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
